### PR TITLE
feat: add duplicate detection and reprocessing override (Phase 6)

### DIFF
--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -121,15 +121,17 @@ Daily Schedule: EventBridge → Lambda → Process 24hr files → S3 (output) �
 - [x] **Enhanced email body** with detailed property breakdown (property name, business date, JE/StatJE record counts)
 - [x] **Date range display** for multi-day processing batches
 
-### Phase 6: Duplicate Detection & Reprocessing Override 🔜 **[NEXT]**
-- [ ] Check incoming files against historical processed files
-- [ ] Duplicate detection based on **property ID + business date** (not file content)
-- [ ] O(1) lookup using S3 HeadObject (scales infinitely, ~50ms per check)
-- [ ] Skip duplicate files to prevent reprocessing same property/date
-- [ ] **Override email address** configuration in Parameter Store
-- [ ] Allow reprocessing when file comes from designated override email
-- [ ] Include skipped duplicates in email summary
-- [ ] Logging for duplicate detection decisions
+### Phase 6: Duplicate Detection & Reprocessing Override ✅ **[COMPLETE]**
+- [x] Check incoming files against historical processed files
+- [x] Duplicate detection based on **property name + business date** (not file content)
+- [x] O(1) lookup using S3 HeadObject (scales infinitely, ~50ms per check)
+- [x] Skip duplicate files to prevent reprocessing same property/date
+- [x] **Override email address** configuration in Parameter Store (`/report-builder/{env}/email/override-sender`)
+- [x] Allow reprocessing when file comes from designated override email
+- [x] Include skipped duplicates in email summary (HTML + plain text)
+- [x] Logging for duplicate detection decisions
+- [x] Processed markers written to `processed-markers/{businessDate}/{property}.json` in S3
+- [x] `DuplicateDetector` service with full unit test coverage
 
 ### Phase 7: Day-to-Day Comparison Engine
 - [ ] Enhanced S3 storage structure for processed daily data
@@ -383,10 +385,12 @@ Enhanced S3 Structure:
 2. **✅ COMPLETED**: End-to-end testing with real data from all 11 properties
 3. **✅ COMPLETED**: JE and StatJE file generation with correct NetSuite format
 4. **✅ COMPLETED**: Phase 5 - Email Delivery with enhanced property breakdown
-5. **🚀 NEXT: Phase 6 - Duplicate Detection & Reprocessing Override**:
-   - Check if property + business date already processed (O(1) lookup)
-   - Skip duplicates to prevent reprocessing
-   - Override email allows forced reprocessing
+5. **✅ COMPLETE: Phase 6 - Duplicate Detection & Reprocessing Override**:
+   - Check if property + business date already processed (O(1) S3 HeadObject lookup)
+   - Skip duplicates to prevent reprocessing same property/date
+   - Override email from Parameter Store allows forced reprocessing
+   - Skipped duplicates surfaced in email summary
+6. **🚀 NEXT: Phase 7 - Day-to-Day Comparison Engine**
    - ~$0.01/year additional cost, ~50ms per file check
    - Scales infinitely (same performance at 100 files or 100 million)
 6. **Future: Phase 7 - Day-to-Day Comparison**:

--- a/infrastructure/lib/constructs/storage-construct.ts
+++ b/infrastructure/lib/constructs/storage-construct.ts
@@ -195,6 +195,7 @@ export class StorageConstruct extends Construct {
         effect: iam.Effect.ALLOW,
         actions: [
           's3:GetObject',
+          's3:HeadObject',
           's3:PutObject',
           's3:DeleteObject',
           's3:ListBucket',

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,50 +241,50 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch": {
-      "version": "3.998.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.998.0.tgz",
-      "integrity": "sha512-aaKNbVUB6cGwGecFn7/GAs48AcKEfGoRIOlJ5oukbJzpdgAwp13MVCi+de3yn01qF9tDaMjItf+H1BL9hnZ2wA==",
+      "version": "3.1013.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1013.0.tgz",
+      "integrity": "sha512-fnCgnuL1v8pF42g4FCDp+l5ZDhBKZLLqb4/ONIXYlxxBS09UJwb45LvCJ5ys5uluMRGyweQMPSNEUCOJtjnVgQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/credential-provider-node": "^3.972.13",
-        "@aws-sdk/middleware-host-header": "^3.972.5",
-        "@aws-sdk/middleware-logger": "^3.972.5",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.5",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@aws-sdk/util-user-agent-browser": "^3.972.5",
-        "@aws-sdk/util-user-agent-node": "^3.972.13",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/core": "^3.23.6",
-        "@smithy/fetch-http-handler": "^5.3.11",
-        "@smithy/hash-node": "^4.2.10",
-        "@smithy/invalid-dependency": "^4.2.10",
-        "@smithy/middleware-compression": "^4.3.35",
-        "@smithy/middleware-content-length": "^4.2.10",
-        "@smithy/middleware-endpoint": "^4.4.20",
-        "@smithy/middleware-retry": "^4.4.37",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/node-http-handler": "^4.4.12",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-body-length-node": "^4.2.2",
-        "@smithy/util-defaults-mode-browser": "^4.3.36",
-        "@smithy/util-defaults-mode-node": "^4.2.39",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
-        "@smithy/util-waiter": "^4.2.10",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/credential-provider-node": "^3.972.23",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.9",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-compression": "^4.3.41",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.13",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -292,53 +292,53 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.998.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.998.0.tgz",
-      "integrity": "sha512-K6dEferMMNU7uxXqSUAt4bnK2UpfHHsF3x4limfonX1bG3rniXxaZSYsj2PRUaXC/dE4Hpq/gwgeO1n5MPb66A==",
+      "version": "3.1013.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1013.0.tgz",
+      "integrity": "sha512-PJnDWZ4uSo7Z5yH4cOu4OepN+kluUpwmBk9ggIS7OA9Y4CIr+1DQpSNAC40a+8EG7GtGDpS/FlE36P6Uqswblw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/credential-provider-node": "^3.972.13",
-        "@aws-sdk/middleware-host-header": "^3.972.5",
-        "@aws-sdk/middleware-logger": "^3.972.5",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.5",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@aws-sdk/util-user-agent-browser": "^3.972.5",
-        "@aws-sdk/util-user-agent-node": "^3.972.13",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/core": "^3.23.6",
-        "@smithy/eventstream-serde-browser": "^4.2.10",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.10",
-        "@smithy/eventstream-serde-node": "^4.2.10",
-        "@smithy/fetch-http-handler": "^5.3.11",
-        "@smithy/hash-node": "^4.2.10",
-        "@smithy/invalid-dependency": "^4.2.10",
-        "@smithy/middleware-content-length": "^4.2.10",
-        "@smithy/middleware-endpoint": "^4.4.20",
-        "@smithy/middleware-retry": "^4.4.37",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/node-http-handler": "^4.4.12",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-body-length-node": "^4.2.2",
-        "@smithy/util-defaults-mode-browser": "^4.3.36",
-        "@smithy/util-defaults-mode-node": "^4.2.39",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/util-stream": "^4.5.15",
-        "@smithy/util-utf8": "^4.2.1",
-        "@smithy/util-waiter": "^4.2.10",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/credential-provider-node": "^3.972.23",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.9",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
+        "@smithy/eventstream-serde-node": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.13",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -346,64 +346,64 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.998.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.998.0.tgz",
-      "integrity": "sha512-XkJ6GN+egutEHSa9+t4OngCRyyP6Zl+4FX+hN7rDqlLjPuK++NHdMVrRSaVq1/H1m0+Nif0Rtz1BiTYP/htmvg==",
+      "version": "3.1013.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1013.0.tgz",
+      "integrity": "sha512-vFdyRyRatF+xP9Fi+4alZkmzZadqOAM34Pm6SUZsYtumNrWkgMc/pFWITnsq6eltM8qcV/vcinQ1ZBXWm/PlKg==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/credential-provider-node": "^3.972.13",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.5",
-        "@aws-sdk/middleware-expect-continue": "^3.972.5",
-        "@aws-sdk/middleware-flexible-checksums": "^3.973.0",
-        "@aws-sdk/middleware-host-header": "^3.972.5",
-        "@aws-sdk/middleware-location-constraint": "^3.972.5",
-        "@aws-sdk/middleware-logger": "^3.972.5",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.14",
-        "@aws-sdk/middleware-ssec": "^3.972.5",
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.5",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.2",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@aws-sdk/util-user-agent-browser": "^3.972.5",
-        "@aws-sdk/util-user-agent-node": "^3.972.13",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/core": "^3.23.6",
-        "@smithy/eventstream-serde-browser": "^4.2.10",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.10",
-        "@smithy/eventstream-serde-node": "^4.2.10",
-        "@smithy/fetch-http-handler": "^5.3.11",
-        "@smithy/hash-blob-browser": "^4.2.11",
-        "@smithy/hash-node": "^4.2.10",
-        "@smithy/hash-stream-node": "^4.2.10",
-        "@smithy/invalid-dependency": "^4.2.10",
-        "@smithy/md5-js": "^4.2.10",
-        "@smithy/middleware-content-length": "^4.2.10",
-        "@smithy/middleware-endpoint": "^4.4.20",
-        "@smithy/middleware-retry": "^4.4.37",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/node-http-handler": "^4.4.12",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-body-length-node": "^4.2.2",
-        "@smithy/util-defaults-mode-browser": "^4.3.36",
-        "@smithy/util-defaults-mode-node": "^4.2.39",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/util-stream": "^4.5.15",
-        "@smithy/util-utf8": "^4.2.1",
-        "@smithy/util-waiter": "^4.2.10",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/credential-provider-node": "^3.972.23",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.8",
+        "@aws-sdk/middleware-expect-continue": "^3.972.8",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.2",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-location-constraint": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.22",
+        "@aws-sdk/middleware-ssec": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.9",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
+        "@smithy/eventstream-serde-node": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-blob-browser": "^4.2.13",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/hash-stream-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/md5-js": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.13",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -411,49 +411,49 @@
       }
     },
     "node_modules/@aws-sdk/client-ses": {
-      "version": "3.998.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.998.0.tgz",
-      "integrity": "sha512-98PbrNBPVyfFLGDazNeCmmSvEWr3ijiT0lR8SpzStfPKihQ8BIKQWja36Ma2Wgv2TbkKsoGpuPSrrONP3RM6pQ==",
+      "version": "3.1013.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1013.0.tgz",
+      "integrity": "sha512-qzAej8dmXw/4G6ex0iwAhKYAyHohDoyezj+WZ37ytWx7ZHVdc+gejbmL2YPpwnggvwFQ46fJxxTvUJOOOApYDQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/credential-provider-node": "^3.972.13",
-        "@aws-sdk/middleware-host-header": "^3.972.5",
-        "@aws-sdk/middleware-logger": "^3.972.5",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.5",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@aws-sdk/util-user-agent-browser": "^3.972.5",
-        "@aws-sdk/util-user-agent-node": "^3.972.13",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/core": "^3.23.6",
-        "@smithy/fetch-http-handler": "^5.3.11",
-        "@smithy/hash-node": "^4.2.10",
-        "@smithy/invalid-dependency": "^4.2.10",
-        "@smithy/middleware-content-length": "^4.2.10",
-        "@smithy/middleware-endpoint": "^4.4.20",
-        "@smithy/middleware-retry": "^4.4.37",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/node-http-handler": "^4.4.12",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-body-length-node": "^4.2.2",
-        "@smithy/util-defaults-mode-browser": "^4.3.36",
-        "@smithy/util-defaults-mode-node": "^4.2.39",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
-        "@smithy/util-waiter": "^4.2.10",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/credential-provider-node": "^3.972.23",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.9",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.13",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -461,48 +461,48 @@
       }
     },
     "node_modules/@aws-sdk/client-sns": {
-      "version": "3.998.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.998.0.tgz",
-      "integrity": "sha512-/ZEbHEkRgOcECfsd0E+Moc6aCHu3tL36qa0Zx0/Y4pAWiC6QYmeRvkcf0EisoelfYDUJ0HnE21hts+SfskQ51Q==",
+      "version": "3.1013.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1013.0.tgz",
+      "integrity": "sha512-TXt1yabwZQajpNPku+49prwONAsOSKAKmkxxwbPo2S+PR4c/5uvS7xFewoM0YV13UwonYH1eyu0x388214YXjQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/credential-provider-node": "^3.972.13",
-        "@aws-sdk/middleware-host-header": "^3.972.5",
-        "@aws-sdk/middleware-logger": "^3.972.5",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.5",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@aws-sdk/util-user-agent-browser": "^3.972.5",
-        "@aws-sdk/util-user-agent-node": "^3.972.13",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/core": "^3.23.6",
-        "@smithy/fetch-http-handler": "^5.3.11",
-        "@smithy/hash-node": "^4.2.10",
-        "@smithy/invalid-dependency": "^4.2.10",
-        "@smithy/middleware-content-length": "^4.2.10",
-        "@smithy/middleware-endpoint": "^4.4.20",
-        "@smithy/middleware-retry": "^4.4.37",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/node-http-handler": "^4.4.12",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-body-length-node": "^4.2.2",
-        "@smithy/util-defaults-mode-browser": "^4.3.36",
-        "@smithy/util-defaults-mode-node": "^4.2.39",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/credential-provider-node": "^3.972.23",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.9",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -510,50 +510,50 @@
       }
     },
     "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.998.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.998.0.tgz",
-      "integrity": "sha512-Yy9KwvZqbazHPsj3uCCkOnZwYE7Vtp1dEBBaG6OaB2mjwh6mtPrP+9B7kZrhwx0AaKgOQEH/2L964tDAGr7A+w==",
+      "version": "3.1013.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1013.0.tgz",
+      "integrity": "sha512-dXj4qBDr+9/+cC3LyOdBZSlz5OT/+mNeyS6ncO9he2oVyz5WFBfMjdgQDQBvihWMq4ysrDUbAzbOjVLCYWcOBg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/credential-provider-node": "^3.972.13",
-        "@aws-sdk/middleware-host-header": "^3.972.5",
-        "@aws-sdk/middleware-logger": "^3.972.5",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
-        "@aws-sdk/middleware-sdk-sqs": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.5",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@aws-sdk/util-user-agent-browser": "^3.972.5",
-        "@aws-sdk/util-user-agent-node": "^3.972.13",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/core": "^3.23.6",
-        "@smithy/fetch-http-handler": "^5.3.11",
-        "@smithy/hash-node": "^4.2.10",
-        "@smithy/invalid-dependency": "^4.2.10",
-        "@smithy/md5-js": "^4.2.10",
-        "@smithy/middleware-content-length": "^4.2.10",
-        "@smithy/middleware-endpoint": "^4.4.20",
-        "@smithy/middleware-retry": "^4.4.37",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/node-http-handler": "^4.4.12",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-body-length-node": "^4.2.2",
-        "@smithy/util-defaults-mode-browser": "^4.3.36",
-        "@smithy/util-defaults-mode-node": "^4.2.39",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/credential-provider-node": "^3.972.23",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-sdk-sqs": "^3.972.16",
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.9",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/md5-js": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -561,49 +561,49 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.998.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.998.0.tgz",
-      "integrity": "sha512-/s/K0C+kkKerSyXphU0BoayG2VeZjolu7m4Ww8UZFOkZJ6F+PEHWvz7a0BpEcvXUZPxEFW87Sd2O9nCcTO75Tw==",
+      "version": "3.1013.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1013.0.tgz",
+      "integrity": "sha512-Ecy8u741Q6FsOjRVaUgPkywF6RFcDbH1nUZ7NnT9Y1EY5ChXxxcjBydk1MdxRRAf/FIXfhjVH+XShqHKOEN29Q==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/credential-provider-node": "^3.972.13",
-        "@aws-sdk/middleware-host-header": "^3.972.5",
-        "@aws-sdk/middleware-logger": "^3.972.5",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.5",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@aws-sdk/util-user-agent-browser": "^3.972.5",
-        "@aws-sdk/util-user-agent-node": "^3.972.13",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/core": "^3.23.6",
-        "@smithy/fetch-http-handler": "^5.3.11",
-        "@smithy/hash-node": "^4.2.10",
-        "@smithy/invalid-dependency": "^4.2.10",
-        "@smithy/middleware-content-length": "^4.2.10",
-        "@smithy/middleware-endpoint": "^4.4.20",
-        "@smithy/middleware-retry": "^4.4.37",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/node-http-handler": "^4.4.12",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-body-length-node": "^4.2.2",
-        "@smithy/util-defaults-mode-browser": "^4.3.36",
-        "@smithy/util-defaults-mode-node": "^4.2.39",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
-        "@smithy/util-waiter": "^4.2.10",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/credential-provider-node": "^3.972.23",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.9",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.13",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -611,22 +611,22 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.14.tgz",
-      "integrity": "sha512-iAQ1jIGESTVjoqNNY9VlsE9FnCz+Hc8s+dgurF6WrgFyVIw+uggH+V102RFhwjRv4dLSSLfzjDwvQnLszov7TQ==",
+      "version": "3.973.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.22.tgz",
+      "integrity": "sha512-lY6g5L95jBNgOUitUhfV2N/W+i08jHEl3xuLODYSQH5Sf50V+LkVYBSyZRLtv2RyuXZXiV7yQ+acpswK1tlrOA==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/xml-builder": "^3.972.7",
-        "@smithy/core": "^3.23.6",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/signature-v4": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.14",
+        "@smithy/core": "^3.23.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -634,11 +634,11 @@
       }
     },
     "node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.2.tgz",
-      "integrity": "sha512-mhTYqkvoC9pm8Lm7KWmH/BDXylzwOTnqqbix4mUG/AODazcigIKRYkzPc2bld6q4h9q1asQCiPC2S1Q6rvSjIQ==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.5.tgz",
+      "integrity": "sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -646,14 +646,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.12.tgz",
-      "integrity": "sha512-WPtj/iAYHHd+NDM6AZoilZwUz0nMaPxbTPGLA7nhyIYRZN2L8trqfbNvm7g/Jr3gzfKp1LpO6AtBTnrhz9WW2g==",
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.20.tgz",
+      "integrity": "sha512-vI0QN96DFx3g9AunfOWF3CS4cMkqFiR/WM/FyP9QHr5rZ2dKPkYwP3tCgAOvGuu9CXI7dC1vU2FVUuZ+tfpNvQ==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -661,19 +661,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.14.tgz",
-      "integrity": "sha512-umtjCicH2o/Fcc8Fu1562UkDyt6gql4czTYVlUfHfAM8S4QEKggzmtHYYYpPfQcjFj1ajyy68ahYSuF67x4ptQ==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.22.tgz",
+      "integrity": "sha512-aS/81smalpe7XDnuQfOq4LIPuaV2PRKU2aMTrHcqO5BD4HwO5kESOHNcec2AYfBtLtIDqgF6RXisgBnfK/jt0w==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/fetch-http-handler": "^5.3.11",
-        "@smithy/node-http-handler": "^4.4.12",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-stream": "^4.5.15",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -681,23 +681,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.12.tgz",
-      "integrity": "sha512-qjzgnMl6GIBbVeK74jBqSF07+s6kyeZl5R88qjMs302JlqkxE57jkvflDmZ9I017ffEWqIUa9/M4Hfp28qyu1g==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.22.tgz",
+      "integrity": "sha512-rpF8fBT0LllMDp78s62aL2A/8MaccjyJ0ORzqu+ZADeECLSrrCWIeeXsuRam+pxiAMkI1uIyDZJmgLGdadkPXw==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/credential-provider-env": "^3.972.12",
-        "@aws-sdk/credential-provider-http": "^3.972.14",
-        "@aws-sdk/credential-provider-login": "^3.972.12",
-        "@aws-sdk/credential-provider-process": "^3.972.12",
-        "@aws-sdk/credential-provider-sso": "^3.972.12",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.12",
-        "@aws-sdk/nested-clients": "^3.996.2",
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/credential-provider-imds": "^4.2.10",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/credential-provider-env": "^3.972.20",
+        "@aws-sdk/credential-provider-http": "^3.972.22",
+        "@aws-sdk/credential-provider-login": "^3.972.22",
+        "@aws-sdk/credential-provider-process": "^3.972.20",
+        "@aws-sdk/credential-provider-sso": "^3.972.22",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -705,17 +705,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.12.tgz",
-      "integrity": "sha512-AO57y46PzG24bJzxWLk+FYJG6MzxvXoFXnOKnmKUGV43ub4/FS/4Rz7zCC6ThqUotgqEFd30l5LTAd65RP65pg==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.22.tgz",
+      "integrity": "sha512-u33CO9zeNznlVSg9tWTCRYxaGkqr1ufU6qeClpmzAabXZa8RZxQoVXxL5T53oZJFzQYj+FImORCSsi7H7B77gQ==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/nested-clients": "^3.996.2",
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -723,21 +723,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.13.tgz",
-      "integrity": "sha512-ME2sgus+gFRtiudy5Xqj9iT/tj8lHOIGrFgktuO5skJU4EngOvTZ1Hpj8mknrW4FgWXmpWhc88NtEscUuuDpKw==",
+      "version": "3.972.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.23.tgz",
+      "integrity": "sha512-U8tyLbLOZItuVWTH0ay9gWo4xMqZwqQbg1oMzdU4FQSkTpqXemm4X0uoKBR6llqAStgBp30ziKFJHTA43l4qMw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.12",
-        "@aws-sdk/credential-provider-http": "^3.972.14",
-        "@aws-sdk/credential-provider-ini": "^3.972.12",
-        "@aws-sdk/credential-provider-process": "^3.972.12",
-        "@aws-sdk/credential-provider-sso": "^3.972.12",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.12",
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/credential-provider-imds": "^4.2.10",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/credential-provider-env": "^3.972.20",
+        "@aws-sdk/credential-provider-http": "^3.972.22",
+        "@aws-sdk/credential-provider-ini": "^3.972.22",
+        "@aws-sdk/credential-provider-process": "^3.972.20",
+        "@aws-sdk/credential-provider-sso": "^3.972.22",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -745,15 +745,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.12.tgz",
-      "integrity": "sha512-msxrHBpVP5AOIDohNPCINUtL47f7XI1TEru3N13uM3nWUMvIRA1vFa8Tlxbxm1EntPPvLAxRmvE5EbjDjOZkbw==",
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.20.tgz",
+      "integrity": "sha512-QRfk7GbA4/HDRjhP3QYR6QBr/QKreVoOzvvlRHnOuGgYJkeoPgPY3LAI1kK1ZMgZ4hH9KiGp757/ntol+INAig==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -761,17 +761,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.12.tgz",
-      "integrity": "sha512-D5iC5546hJyhobJN0szOT4KVeJQ8z/meZq2B3lEDZFcvHONKw+tzq36DAJUy3qLTueeB2geSxiHXngQlA11eoA==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.22.tgz",
+      "integrity": "sha512-4vqlSaUbBj4aNPVKfB6yXuIQ2Z2mvLfIGba2OzzF6zUkN437/PGWsxBU2F8QPSFHti6seckvyCXidU3H+R8NvQ==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/nested-clients": "^3.996.2",
-        "@aws-sdk/token-providers": "3.998.0",
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/token-providers": "3.1013.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -779,16 +779,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.12.tgz",
-      "integrity": "sha512-yluBahBVsduoA/zgV0NAXtwwXvQ6tNn95dNA3Hg+vISdiPWA46QY0d9PLO2KpNbjtm+1oGcWxemS4fYTwJ0W1w==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.22.tgz",
+      "integrity": "sha512-/wN1CYg2rVLhW8/jLxMWacQrkpaynnL+4j/Z+e6X1PfoE6NiC0BeOw3i0JmtZrKun85wNV5GmspvuWJihfeeUw==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/nested-clients": "^3.996.2",
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -796,16 +796,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.5.tgz",
-      "integrity": "sha512-4+PMX1vuPoALVhuyW7M2GkV9XrkUeuqhuXPs1IkGo2/5dFM8TxM7gnB/evSNVF/o6NXwnO4Sc+6UtGCDhI6RLg==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.8.tgz",
+      "integrity": "sha512-WR525Rr2QJSETa9a050isktyWi/4yIGcmY3BQ1kpHqb0LqUglQHCS8R27dTJxxWNZvQ0RVGtEZjTCbZJpyF3Aw==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-arn-parser": "^3.972.2",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-config-provider": "^4.2.1",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -813,13 +813,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.5.tgz",
-      "integrity": "sha512-8dM11mmRZ8ZrDdkBL5q7Rslhua/nASrUhis2BJuwz2hJ+QsyyuOtr2vvc83fM91YXq18oe26bZI9tboroSo4NA==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.8.tgz",
+      "integrity": "sha512-5DTBTiotEES1e2jOHAq//zyzCjeMB78lEHd35u15qnrid4Nxm7diqIf9fQQ3Ov0ChH1V3Vvt13thOnrACmfGVQ==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -827,23 +827,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.973.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.973.0.tgz",
-      "integrity": "sha512-RAYonYq4Tk93fB+QlLlCEaB1nHSM4lTWq4KBJ7s5bh6y30uGaVTmFELSeWlfLVJipyJ/T1FBWmrYETMcNsESoQ==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.2.tgz",
+      "integrity": "sha512-4soN/N4R6ptdnHw7hXPVDZMIIL+vhN8rwtLdDyS0uD7ExhadtJzolTBIM5eKSkbw5uBEbIwtJc8HCG2NM6tN/g==",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/crc64-nvme": "^3.972.2",
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/is-array-buffer": "^4.2.1",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-stream": "^4.5.15",
-        "@smithy/util-utf8": "^4.2.1",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/crc64-nvme": "^3.972.5",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -851,13 +851,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.5.tgz",
-      "integrity": "sha512-dVA0m1cEQ2iA6yB19aHvWNeUVTuvTt3AXzT0aiIu2uxk0S7AcmwDCDaRgYa/v+eFHcJVxEnpYTozqA7X62xinw==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -865,12 +865,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.5.tgz",
-      "integrity": "sha512-BC8MQUaG78oEGOjDdyGBLQCbio/KNeeMcbN8GZumW6yowe5MHyt//FJr8sipA1/hLOZ++lfpGk9bdaSo7LUpOw==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.8.tgz",
+      "integrity": "sha512-KaUoFuoFPziIa98DSQsTPeke1gvGXlc5ZGMhy+b+nLxZ4A7jmJgLzjEF95l8aOQN2T/qlPP3MrAyELm8ExXucw==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -878,12 +878,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.5.tgz",
-      "integrity": "sha512-03RqplLZjUTkYi0dDPR/bbOLnDLFNdaVvNENgA3XK7Ph1MhEBhUYlgoGfOyRAKApDZ+WG4ykOoA8jI8J04jmFA==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -891,14 +891,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.5.tgz",
-      "integrity": "sha512-2QSuuVkpHTe84+mDdnFjHX8rAP3g0yYwLVAhS3lQN1rW5Z/zNsf8/pYQrLjLO4n4sPCsUAkTa0Vrod0lk+o1Tg==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
+      "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.6",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -906,23 +906,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.14.tgz",
-      "integrity": "sha512-qnNWgL2WLZbWQmrr+yB23ivo/L7POJxxFlQxhfDGM/NQ4OfG7YORtqwLps0mOMI8pH22kVeoNu+PB8cgRXLoqQ==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.22.tgz",
+      "integrity": "sha512-dkUcRxF4rVpPbyHpxjCApGK6b7JpnSeo7tDoNakpRKmiLMCqgy4tlGBgeEYJnZgLrA4xc5jVKuXgvgqKqU18Kw==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-arn-parser": "^3.972.2",
-        "@smithy/core": "^3.23.6",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/signature-v4": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-config-provider": "^4.2.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-stream": "^4.5.15",
-        "@smithy/util-utf8": "^4.2.1",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -930,15 +930,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.10.tgz",
-      "integrity": "sha512-qlbIQfRQlJgRGg7dbZBNmIrfHXQZIHRgvG0hpf4CJQaZfcIYXMedjTACEY9H2tK6mlXhs3ZwsI2axmjkkG7lzA==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.16.tgz",
+      "integrity": "sha512-RU6LLNYF7vfsSAvVXZ5Sx+zvPQ3lwW8GULDvKYtLevvKwRtPKakz8HehG6vNZ6pW8XY2U0vilF26jFhnSBzQfA==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-hex-encoding": "^4.2.1",
-        "@smithy/util-utf8": "^4.2.1",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -946,12 +946,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.5.tgz",
-      "integrity": "sha512-AfQgwVjK071d1F75jX49CE5KJTlAWwMKqHJoGzf8nUD04iSHw+93rzKSGAFHu3v06k32algI6pF+ctqV/Fjc1A==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.8.tgz",
+      "integrity": "sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -959,16 +959,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.14.tgz",
-      "integrity": "sha512-PzDz+yRAQuIzd+4ZY3s6/TYRzlNKAn4Gae3E5uLV7NnYHqrZHFoAfKE4beXcu3C51pA2/FQ3X2qOGSYqUoN1WQ==",
+      "version": "3.972.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.23.tgz",
+      "integrity": "sha512-HQu8QoqGZZTvg0Spl9H39QTsSMFwgu+8yz/QGKndXFLk9FZMiCiIgBCVlTVKMDvVbgqIzD9ig+/HmXsIL2Rb+g==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@smithy/core": "^3.23.6",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -976,47 +977,47 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.2.tgz",
-      "integrity": "sha512-W+u6EM8WRxOIhAhR2mXMHSaUygqItpTehkgxLwJngXqr9RlAR4t6CtECH7o7QK0ct3oyi5Z8ViDHtPbel+D2Rg==",
+      "version": "3.996.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.12.tgz",
+      "integrity": "sha512-KLdQGJPSm98uLINolQ0Tol8OAbk7g0Y7zplHJ1K83vbMIH13aoCvR6Tho66xueW4l4aZlEgVGLWBnD8ifUMsGQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/middleware-host-header": "^3.972.5",
-        "@aws-sdk/middleware-logger": "^3.972.5",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.5",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@aws-sdk/util-user-agent-browser": "^3.972.5",
-        "@aws-sdk/util-user-agent-node": "^3.972.13",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/core": "^3.23.6",
-        "@smithy/fetch-http-handler": "^5.3.11",
-        "@smithy/hash-node": "^4.2.10",
-        "@smithy/invalid-dependency": "^4.2.10",
-        "@smithy/middleware-content-length": "^4.2.10",
-        "@smithy/middleware-endpoint": "^4.4.20",
-        "@smithy/middleware-retry": "^4.4.37",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/node-http-handler": "^4.4.12",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-body-length-node": "^4.2.2",
-        "@smithy/util-defaults-mode-browser": "^4.3.36",
-        "@smithy/util-defaults-mode-node": "^4.2.39",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.9",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.26",
+        "@smithy/middleware-retry": "^4.4.43",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.42",
+        "@smithy/util-defaults-mode-node": "^4.2.45",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1024,14 +1025,14 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.5.tgz",
-      "integrity": "sha512-AOitrygDwfTNCLCW7L+GScDy1p49FZ6WutTUFWROouoPetfVNmpL4q8TWD3MhfY/ynhoGhleUQENrBH374EU8w==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.8.tgz",
+      "integrity": "sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1039,15 +1040,15 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.2.tgz",
-      "integrity": "sha512-fUWHKtgeTfTEML5gi3yugy7caaoe7/8YdM/H0gQXuSDYNL3hORyGST5RyLnhfVDeNgypANLpIP6wzzIq74kEwQ==",
+      "version": "3.996.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.10.tgz",
+      "integrity": "sha512-yJSbFTedh1McfqXa9wZzjchqQ2puq5PI/qRz5kUjg2UXS5mO4MBYBbeXaZ2rp/h+ZbkcYEdo4Qsiah9psyoxrA==",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.14",
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/signature-v4": "^5.3.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.22",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1055,16 +1056,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.998.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.998.0.tgz",
-      "integrity": "sha512-JFzi44tQnENZQ+1DYcHfoa/wTRKkccz0VsNMow0rvsxZtqUEkeV2pYFbir35mHTyUKju9995ay1MAGxLt1dpRA==",
+      "version": "3.1013.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1013.0.tgz",
+      "integrity": "sha512-IL1c54UvbuERrs9oLm5rvkzMciwhhpn1FL0SlC3XUMoLlFhdBsWJgQKK8O5fsQLxbFVqjbjFx9OBkrn44X9PHw==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/nested-clients": "^3.996.2",
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.22",
+        "@aws-sdk/nested-clients": "^3.996.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1072,11 +1073,11 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.3.tgz",
-      "integrity": "sha512-tma6D8/xHZHJEUqmr6ksZjZ0onyIUqKDQLyp50ttZJmS0IwFYzxBgp5CxFvpYAnah52V3UtgrqGA6E83gtT7NQ==",
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1084,9 +1085,9 @@
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.2.tgz",
-      "integrity": "sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -1095,14 +1096,14 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.2.tgz",
-      "integrity": "sha512-83E6T1CKi0/IozPzqRBKqduW0mS4UQdI3soBH6CG7UgupTADWunqEMOTuPWCs9XGjpJJ4ujj+yu7pn8svhp5yg==",
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-endpoints": "^3.3.1",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1121,25 +1122,26 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.5.tgz",
-      "integrity": "sha512-2ja1WqtuBaEAMgVoHYuWx393DF6ULqdt3OozeO7BosqouYaoU47Adtp9vEF+GImSG/Q8A+dqfwDULTTdMkHGUQ==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.13.tgz",
-      "integrity": "sha512-PHErmuu+v6iAST48zcsB2cYwDKW45gk6qCp49t1p0NGZ4EaFPr/tA5jl0X/ekDwvWbuT0LTj++fjjdVQAbuh0Q==",
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.9.tgz",
+      "integrity": "sha512-jeFqqp8KD/P5O+qeKxyGeu7WEVIZFNprnkaDjGmBOjwxYwafCBhpxTgV1TlW6L8e76Vh/siNylNmN/OmSIFBUQ==",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.23",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1155,12 +1157,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.9.tgz",
-      "integrity": "sha512-ItnlMgSqkPrUfJs7EsvU/01zw5UeIb2tNPhD09LBLHbg+g+HDiKibSLwpkuz/ZIlz4F2IMn+5XgE4AK/pfPuog==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.14.tgz",
+      "integrity": "sha512-G/Yd8Bnnyh8QrqLf8jWJbixEnScUFW24e/wOBGYdw1Cl4r80KX/DvHyM2GVZ2vTp7J4gTEr8IXJlTadA8+UfuQ==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "fast-xml-parser": "5.4.1",
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1168,9 +1170,9 @@
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
-      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -2372,11 +2374,11 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.10.tgz",
-      "integrity": "sha512-qocxM/X4XGATqQtUkbE9SPUB6wekBi+FyJOMbPj0AhvyvFGYEmOlz6VB22iMePCQsFmMIvFSeViDvA7mZJG47g==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
+      "integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2384,9 +2386,9 @@
       }
     },
     "node_modules/@smithy/chunked-blob-reader": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.1.tgz",
-      "integrity": "sha512-y5d4xRiD6TzeP5BWlb+Ig/VFqF+t9oANNhGeMqyzU7obw7FYgTgVi50i5JqBTeKp+TABeDIeeXFZdz65RipNtA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
+      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2395,11 +2397,11 @@
       }
     },
     "node_modules/@smithy/chunked-blob-reader-native": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.2.tgz",
-      "integrity": "sha512-QzzYIlf4yg0w5TQaC9VId3B3ugSk1MI/wb7tgcHtd7CBV9gNRKZrhc2EPSxSZuDy10zUZ0lomNMgkc6/VVe8xg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
+      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
       "dependencies": {
-        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2407,15 +2409,15 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.9.tgz",
-      "integrity": "sha512-ejQvXqlcU30h7liR9fXtj7PIAau1t/sFbJpgWPfiYDs7zd16jpH0IsSXKcba2jF6ChTXvIjACs27kNMc5xxE2Q==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
+      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-config-provider": "^4.2.1",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2423,19 +2425,19 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.6",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.6.tgz",
-      "integrity": "sha512-4xE+0L2NrsFKpEVFlFELkIHQddBvMbQ41LRIP74dGCXnY1zQ9DgksrBcRBDJT+iOzGy4VEJIeU3hkUK5mn06kg==",
+      "version": "3.23.12",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
+      "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-stream": "^4.5.15",
-        "@smithy/util-utf8": "^4.2.1",
-        "@smithy/uuid": "^1.1.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2443,14 +2445,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.10.tgz",
-      "integrity": "sha512-3bsMLJJLTZGZqVGGeBVFfLzuRulVsGTj12BzRKODTHqUABpIr0jMN1vN3+u6r2OfyhAQ2pXaMZWX/swBK5I6PQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2458,13 +2460,13 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.10.tgz",
-      "integrity": "sha512-A4ynrsFFfSXUHicfTcRehytppFBcY3HQxEGYiyGktPIOye3Ot7fxpiy4VR42WmtGI4Wfo6OXt/c1Ky1nUFxYYQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
+      "integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-hex-encoding": "^4.2.1",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2472,12 +2474,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.10.tgz",
-      "integrity": "sha512-0xupsu9yj9oDVuQ50YCTS9nuSYhGlrwqdaKQel9y2Fz7LU9fNErVlw9N0o4pm4qqvWEGbSTI4HKc6XJfB30MVw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
+      "integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2485,11 +2487,11 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.10.tgz",
-      "integrity": "sha512-8kn6sinrduk0yaYHMJDsNuiFpXwQwibR7n/4CDUqn4UgaG+SeBHu5jHGFdU9BLFAM7Q4/gvr9RYxBHz9/jKrhA==",
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
+      "integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2497,12 +2499,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.10.tgz",
-      "integrity": "sha512-uUrxPGgIffnYfvIOUmBM5i+USdEBRTdh7mLPttjphgtooxQ8CtdO1p6K5+Q4BBAZvKlvtJ9jWyrWpBJYzBKsyQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
+      "integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2510,12 +2512,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.10.tgz",
-      "integrity": "sha512-aArqzOEvcs2dK+xQVCgLbpJQGfZihw8SD4ymhkwNTtwKbnrzdhJsFDKuMQnam2kF69WzgJYOU5eJlCx+CA32bw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
+      "integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2523,14 +2525,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.11.tgz",
-      "integrity": "sha512-wbTRjOxdFuyEg0CpumjZO0hkUl+fetJFqxNROepuLIoijQh51aMBmzFLfoQdwRjxsuuS2jizzIUTjPWgd8pd7g==",
+      "version": "5.3.15",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/querystring-builder": "^4.2.10",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-base64": "^4.3.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2538,13 +2540,13 @@
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.11.tgz",
-      "integrity": "sha512-DrcAx3PM6AEbWZxsKl6CWAGnVwiz28Wp1ZhNu+Hi4uI/6C1PIZBIaPM2VoqBDAsOWbM6ZVzOEQMxFLLdmb4eBQ==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.13.tgz",
+      "integrity": "sha512-YrF4zWKh+ghLuquldj6e/RzE3xZYL8wIPfkt0MqCRphVICjyyjH8OwKD7LLlKpVEbk4FLizFfC1+gwK6XQdR3g==",
       "dependencies": {
-        "@smithy/chunked-blob-reader": "^5.2.1",
-        "@smithy/chunked-blob-reader-native": "^4.2.2",
-        "@smithy/types": "^4.13.0",
+        "@smithy/chunked-blob-reader": "^5.2.2",
+        "@smithy/chunked-blob-reader-native": "^4.2.3",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2552,13 +2554,13 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.10.tgz",
-      "integrity": "sha512-1VzIOI5CcsvMDvP3iv1vG/RfLJVVVc67dCRyLSB2Hn9SWCZrDO3zvcIzj3BfEtqRW5kcMg5KAeVf1K3dR6nD3w==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-buffer-from": "^4.2.1",
-        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2566,12 +2568,12 @@
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.10.tgz",
-      "integrity": "sha512-w78xsYrOlwXKwN5tv1GnKIRbHb1HygSpeZMP6xDxCPGf1U/xDHjCpJu64c5T35UKyEPwa0bPeIcvU69VY3khUA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.12.tgz",
+      "integrity": "sha512-O3YbmGExeafuM/kP7Y8r6+1y0hIh3/zn6GROx0uNlB54K9oihAL75Qtc+jFfLNliTi6pxOAYZrRKD9A7iA6UFw==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2579,11 +2581,11 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.10.tgz",
-      "integrity": "sha512-vy9KPNSFUU0ajFYk0sDZIYiUlAWGEAhRfehIr5ZkdFrRFTAuXEPUd41USuqHU6vvLX4r6Q9X7MKBco5+Il0Org==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2591,9 +2593,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.1.tgz",
-      "integrity": "sha512-Yfu664Qbf1B4IYIsYgKoABt010daZjkaCRvdU/sPnZG6TtHOB0md0RjNdLGzxe5UIdn9js4ftPICzmkRa9RJ4Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2602,12 +2604,12 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.10.tgz",
-      "integrity": "sha512-Op+Dh6dPLWTjWITChFayDllIaCXRofOed8ecpggTC5fkh8yXes0vAEX7gRUfjGK+TlyxoCAA05gHbZW/zB9JwQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.12.tgz",
+      "integrity": "sha512-W/oIpHCpWU2+iAkfZYyGWE+qkpuf3vEXHLxQQDx9FPNZTTdnul0dZ2d/gUFrtQ5je1G2kp4cjG0/24YueG2LbQ==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2615,18 +2617,18 @@
       }
     },
     "node_modules/@smithy/middleware-compression": {
-      "version": "4.3.35",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.3.35.tgz",
-      "integrity": "sha512-lZp486kpmXBmXoPedbAzs982q+fRRwyv7O3+5tSkt8J8xf64Mod+I0l5P+CRfKzqwoRt0+1YFbBx97aHS7xYPw==",
+      "version": "4.3.41",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.3.41.tgz",
+      "integrity": "sha512-lJ/yTWaPQZfvT5GJUgGpjjmG4ZgNhlPmvAN+SfQKcsNBApY+CaW2vg/x7GhsD3g/liKlo7suMAAZNK5RVQ9OIQ==",
       "dependencies": {
-        "@smithy/core": "^3.23.6",
-        "@smithy/is-array-buffer": "^4.2.1",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-config-provider": "^4.2.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/core": "^3.23.12",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
         "fflate": "0.8.1",
         "tslib": "^2.6.2"
       },
@@ -2635,12 +2637,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.10.tgz",
-      "integrity": "sha512-TQZ9kX5c6XbjhaEBpvhSvMEZ0klBs1CFtOdPFwATZSbC9UeQfKHPLPN9Y+I6wZGMOavlYTOlHEPDrt42PMSH9w==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2648,17 +2650,17 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.20",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.20.tgz",
-      "integrity": "sha512-9W6Np4ceBP3XCYAGLoMCmn8t2RRVzuD1ndWPLBbv7H9CrwM9Bprf6Up6BM9ZA/3alodg0b7Kf6ftBK9R1N04vw==",
+      "version": "4.4.27",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.27.tgz",
+      "integrity": "sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==",
       "dependencies": {
-        "@smithy/core": "^3.23.6",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2666,18 +2668,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.37",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.37.tgz",
-      "integrity": "sha512-/1psZZllBBSQ7+qo5+hhLz7AEPGLx3Z0+e3ramMBEuPK2PfvLK4SrncDB9VegX5mBn+oP/UTDrM6IHrFjvX1ZA==",
+      "version": "4.4.44",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.44.tgz",
+      "integrity": "sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/service-error-classification": "^4.2.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/uuid": "^1.1.1",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2685,12 +2687,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.11.tgz",
-      "integrity": "sha512-STQdONGPwbbC7cusL60s7vOa6He6A9w2jWhoapL0mgVjmR19pr26slV+yoSP76SIssMTX/95e5nOZ6UQv6jolg==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
+      "integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2698,11 +2701,11 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.10.tgz",
-      "integrity": "sha512-pmts/WovNcE/tlyHa8z/groPeOtqtEpp61q3W0nW1nDJuMq/x+hWa/OVQBtgU0tBqupeXq0VBOLA4UZwE8I0YA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2710,13 +2713,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.10.tgz",
-      "integrity": "sha512-UALRbJtVX34AdP2VECKVlnNgidLHA2A7YgcJzwSBg1hzmnO/bZBHl/LDQQyYifzUwp1UOODnl9JJ3KNawpUJ9w==",
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
-        "@smithy/types": "^4.13.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2724,14 +2727,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.12",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.12.tgz",
-      "integrity": "sha512-zo1+WKJkR9x7ZtMeMDAAsq2PufwiLDmkhcjpWPRRkmeIuOm6nq1qjFICSZbnjBvD09ei8KMo26BWxsu2BUU+5w==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
+      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/querystring-builder": "^4.2.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2739,11 +2742,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.10.tgz",
-      "integrity": "sha512-5jm60P0CU7tom0eNrZ7YrkgBaoLFXzmqB0wVS+4uK8PPGmosSrLNf6rRd50UBvukztawZ7zyA8TxlrKpF5z9jw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2751,11 +2754,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.10",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.10.tgz",
-      "integrity": "sha512-2NzVWpYY0tRdfeCJLsgrR89KE3NTWT2wGulhNUxYlRmtRmPwLQwKzhrfVaiNlA9ZpJvbW7cjTVChYKgnkqXj1A==",
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2763,12 +2766,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.10.tgz",
-      "integrity": "sha512-HeN7kEvuzO2DmAzLukE9UryiUvejD3tMp9a1D1NJETerIfKobBUCLfviP6QEk500166eD2IATaXM59qgUI+YDA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-uri-escape": "^4.2.1",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2776,11 +2779,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.10.tgz",
-      "integrity": "sha512-4Mh18J26+ao1oX5wXJfWlTT+Q1OpDR8ssiC9PDOuEgVBGloqg18Fw7h5Ct8DyT9NBYwJgtJ2nLjKKFU6RP1G1Q==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2788,22 +2791,22 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.10.tgz",
-      "integrity": "sha512-0R/+/Il5y8nB/By90o8hy/bWVYptbIfvoTYad0igYQO5RefhNCDmNzqxaMx7K1t/QWo0d6UynqpqN5cCQt1MCg==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
       "dependencies": {
-        "@smithy/types": "^4.13.0"
+        "@smithy/types": "^4.13.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.5.tgz",
-      "integrity": "sha512-pHgASxl50rrtOztgQCPmOXFjRW+mCd7ALr/3uXNzRrRoGV5G2+78GOsQ3HlQuBVHCh9o6xqMNvlIKZjWn4Euug==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2811,17 +2814,17 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.10",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.10.tgz",
-      "integrity": "sha512-Wab3wW8468WqTKIxI+aZe3JYO52/RYT/8sDOdzkUhjnLakLe9qoQqIcfih/qxcF4qWEFoWBszY0mj5uxffaVXA==",
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.1",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-hex-encoding": "^4.2.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-uri-escape": "^4.2.1",
-        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2829,16 +2832,16 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.0.tgz",
-      "integrity": "sha512-R8bQ9K3lCcXyZmBnQqUZJF4ChZmtWT5NLi6x5kgWx5D+/j0KorXcA0YcFg/X5TOgnTCy1tbKc6z2g2y4amFupQ==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.7.tgz",
+      "integrity": "sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==",
       "dependencies": {
-        "@smithy/core": "^3.23.6",
-        "@smithy/middleware-endpoint": "^4.4.20",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-stream": "^4.5.15",
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2846,9 +2849,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
-      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2857,12 +2860,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.10.tgz",
-      "integrity": "sha512-uypjF7fCDsRk26u3qHmFI/ePL7bxxB9vKkE+2WKEciHhz+4QtbzWiHRVNRJwU3cKhrYDYQE3b0MRFtqfLYdA4A==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/querystring-parser": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2870,12 +2873,12 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.1.tgz",
-      "integrity": "sha512-BKGuawX4Doq/bI/uEmg+Zyc36rJKWuin3py89PquXBIBqmbnJwBBsmKhdHfNEp0+A4TDgLmT/3MSKZ1SxHcR6w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.1",
-        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2883,9 +2886,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.1.tgz",
-      "integrity": "sha512-SiJeLiozrAoCrgDBUgsVbmqHmMgg/2bA15AzcbcW+zan7SuyAVHN4xTSbq0GlebAIwlcaX32xacnrG488/J/6g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2894,9 +2897,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.2.tgz",
-      "integrity": "sha512-4rHqBvxtJEBvsZcFQSPQqXP2b/yy/YlB66KlcEgcH2WNoOKCKB03DSLzXmOsXjbl8dJ4OEYTn31knhdznwk7zw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2905,11 +2908,11 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.1.tgz",
-      "integrity": "sha512-/swhmt1qTiVkaejlmMPPDgZhEaWb/HWMGRBheaxwuVkusp/z+ErJyQxO6kaXumOciZSWlmq6Z5mNylCd33X7Ig==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.1",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2917,9 +2920,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.1.tgz",
-      "integrity": "sha512-462id/00U8JWFw6qBuTSWfN5TxOHvDu4WliI97qOIOnuC/g+NDAknTU8eoGXEPlLkRVgWEr03jJBLV4o2FL8+A==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2928,13 +2931,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.36",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.36.tgz",
-      "integrity": "sha512-R0smq7EHQXRVMxkAxtH5akJ/FvgAmNF6bUy/GwY/N20T4GrwjT633NFm0VuRpC+8Bbv8R9A0DoJ9OiZL/M3xew==",
+      "version": "4.3.43",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.43.tgz",
+      "integrity": "sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2942,16 +2945,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.39",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.39.tgz",
-      "integrity": "sha512-otWuoDm35btJV1L8MyHrPl462B07QCdMTktKc7/yM+Psv6KbED/ziXiHnmr7yPHUjfIwE9S8Max0LO24Mo3ZVg==",
+      "version": "4.2.47",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.47.tgz",
+      "integrity": "sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/credential-provider-imds": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/smithy-client": "^4.12.0",
-        "@smithy/types": "^4.13.0",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2959,12 +2962,12 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.1.tgz",
-      "integrity": "sha512-xyctc4klmjmieQiF9I1wssBWleRV0RhJ2DpO8+8yzi2LO1Z+4IWOZNGZGNj4+hq9kdo+nyfrRLmQTzc16Op2Vg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2972,9 +2975,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.1.tgz",
-      "integrity": "sha512-c1hHtkgAWmE35/50gmdKajgGAKV3ePJ7t6UtEmpfCWJmQE9BQAQPz0URUVI89eSkcDqCtzqllxzG28IQoZPvwA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2983,11 +2986,11 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.10.tgz",
-      "integrity": "sha512-LxaQIWLp4y0r72eA8mwPNQ9va4h5KeLM0I3M/HV9klmFaY2kN766wf5vsTzmaOpNNb7GgXAd9a25P3h8T49PSA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2995,12 +2998,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.10.tgz",
-      "integrity": "sha512-HrBzistfpyE5uqTwiyLsFHscgnwB0kgv8vySp7q5kZ0Eltn/tjosaSGGDj/jJ9ys7pWzIP/icE2d+7vMKXLv7A==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.12.tgz",
+      "integrity": "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3008,17 +3011,17 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.15",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.15.tgz",
-      "integrity": "sha512-OlOKnaqnkU9X+6wEkd7mN+WB7orPbCVDauXOj22Q7VtiTkvy7ZdSsOg4QiNAZMgI4OkvNf+/VLUC3VXkxuWJZw==",
+      "version": "4.5.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
+      "integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.11",
-        "@smithy/node-http-handler": "^4.4.12",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-buffer-from": "^4.2.1",
-        "@smithy/util-hex-encoding": "^4.2.1",
-        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3026,9 +3029,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.1.tgz",
-      "integrity": "sha512-YmiUDn2eo2IOiWYYvGQkgX5ZkBSiTQu4FlDo5jNPpAxng2t6Sjb6WutnZV9l6VR4eJul1ABmCrnWBC9hKHQa6Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3037,11 +3040,11 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.1.tgz",
-      "integrity": "sha512-DSIwNaWtmzrNQHv8g7DBGR9mulSit65KSj5ymGEIAknmIN8IpbZefEep10LaMG/P/xquwbmJ1h9ectz8z6mV6g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.1",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3049,12 +3052,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.10.tgz",
-      "integrity": "sha512-4eTWph/Lkg1wZEDAyObwme0kmhEb7J/JjibY2znJdrYRgKbKqB7YoEhhJVJ4R1g/SYih4zuwX7LpJaM8RsnTVg==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.13.tgz",
+      "integrity": "sha512-2zdZ9DTHngRtcYxJK1GUDxruNr53kv5W2Lupe0LMU+Imr6ohQg8M2T14MNkj1Y0wS3FFwpgpGQyvuaMF7CiTmQ==",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.10",
-        "@smithy/types": "^4.13.0",
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3062,9 +3065,9 @@
       }
     },
     "node_modules/@smithy/uuid": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.1.tgz",
-      "integrity": "sha512-dSfDCeihDmZlV2oyr0yWPTUfh07suS+R5OB+FZGiv/hHyK3hrFBW5rR1UYjfa57vBsrP9lciFkRPzebaV1Qujw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -4540,20 +4543,9 @@
       "dev": true
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ]
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -4561,7 +4553,22 @@
         }
       ],
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
+      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.1.3",
         "strnum": "^2.1.2"
       },
       "bin": {
@@ -4636,9 +4643,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "node_modules/foreground-child": {
@@ -5331,26 +5338,26 @@
       }
     },
     "node_modules/mailparser": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.1.tgz",
-      "integrity": "sha512-6vHZcco3fWsDMkf4Vz9iAfxvwrKNGbHx0dV1RKVphQ/zaNY34Buc7D37LSa09jeSeybWzYcTPjhiZFxzVRJedA==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.4.tgz",
+      "integrity": "sha512-ZmCnrMnRod+Cq6h7afn9DMFlT1B5gf484Ji+55NhUR4+w4q9z9d7lHHvL8pXP6kp/ehr8pGLQZBmjHpjvItuTQ==",
       "dependencies": {
         "@zone-eu/mailsplit": "5.4.8",
         "encoding-japanese": "2.2.0",
         "he": "1.2.0",
         "html-to-text": "9.0.5",
-        "iconv-lite": "0.7.0",
+        "iconv-lite": "0.7.2",
         "libmime": "5.3.7",
         "linkify-it": "5.0.0",
-        "nodemailer": "7.0.11",
+        "nodemailer": "8.0.2",
         "punycode.js": "2.3.1",
         "tlds": "1.261.0"
       }
     },
     "node_modules/mailparser/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -5473,9 +5480,9 @@
       "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw=="
     },
     "node_modules/nodemailer": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.11.tgz",
-      "integrity": "sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.2.tgz",
+      "integrity": "sha512-zbj002pZAIkWQFxyAaqoxvn+zoIwRnS40hgjqTXudKOOJkiFFgBeNqjgD3/YCR12sZnrghWYBY+yP1ZucdDRpw==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -5585,6 +5592,20 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -6147,9 +6168,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
+      "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
       "funding": [
         {
           "type": "github",

--- a/src/config/parameter-store.ts
+++ b/src/config/parameter-store.ts
@@ -88,6 +88,23 @@ export class ParameterStoreConfig {
   }
 
   /**
+   * Get override sender email addresses for forcing reprocessing of duplicate files.
+   * When a file arrives from any of these addresses, it bypasses duplicate detection.
+   * Supports a comma-separated list of emails in the parameter value.
+   * Example parameter value: "override@company.com,gm@hotel.com"
+   * @returns Array of lowercase override email addresses, or empty array if not configured
+   */
+  async getOverrideEmails(): Promise<string[]> {
+    const paramName = `/report-builder/${environmentConfig.environment}/email/override-sender`;
+    const value = await this.getParameter(paramName);
+    if (!value) return [];
+    return value
+      .split(",")
+      .map((email) => email.trim().toLowerCase())
+      .filter((email) => email.length > 0);
+  }
+
+  /**
    * Get SES configuration set name
    * @returns SES configuration set name for the current environment
    */

--- a/src/config/property-config.ts
+++ b/src/config/property-config.ts
@@ -120,6 +120,14 @@ const PROPERTY_CONFIGURATIONS: PropertyConfig[] = [
     locationName: "Best Western Windsor Inn",
     creditCardDepositAccount: "10290-707",
   },
+  {
+    propertyName: "FRANCISCAN INN & SUITES",
+    locationInternalId: "36",
+    subsidiaryInternalId: "5",
+    subsidiaryFullName: "FRANCISCAN INN & SUITES",
+    locationName: "Franciscan Inn & Suites",
+    creditCardDepositAccount: "10010-528",
+  },
 ];
 
 /**

--- a/src/email/report-email-sender.ts
+++ b/src/email/report-email-sender.ts
@@ -16,6 +16,7 @@ import { retryOperation } from "../utils/retry";
 import { ParameterStoreConfig } from "../config/parameter-store";
 import { environmentConfig } from "../config/environment";
 import { RetryConfig } from "../types/errors";
+import type { SkippedDuplicate } from "../lambda/file-processor";
 
 /**
  * Details for a single property/date combination
@@ -55,6 +56,8 @@ export interface ReportSummary {
   errors: string[];
   /** Detailed breakdown by property and date (optional for backwards compatibility) */
   propertyDetails?: PropertyDetail[];
+  /** Files skipped because the property+date was already processed */
+  skippedDuplicates?: SkippedDuplicate[];
 }
 
 /**
@@ -375,6 +378,8 @@ export class ReportEmailSender {
     const hasErrors = summary.errors && summary.errors.length > 0;
     const hasPropertyDetails =
       summary.propertyDetails && summary.propertyDetails.length > 0;
+    const hasSkippedDuplicates =
+      summary.skippedDuplicates && summary.skippedDuplicates.length > 0;
 
     // Use detailed view if propertyDetails available, otherwise simple list
     const propertiesSection = hasPropertyDetails
@@ -389,6 +394,26 @@ export class ReportEmailSender {
         <ul style="color: #856404; background-color: #fff3cd; padding: 15px; border-radius: 4px;">
           ${summary.errors.map((e) => `<li>${this.escapeHtml(e)}</li>`).join("\n")}
         </ul>
+      `
+      : "";
+
+    const skippedSection = hasSkippedDuplicates
+      ? `
+        <h3 style="color: #6c757d;">Skipped (Already Processed)</h3>
+        <div style="background-color: #f8f9fa; padding: 15px; border-radius: 4px; border-left: 4px solid #6c757d;">
+          <p style="margin: 0 0 10px 0; font-size: 13px; color: #555;">
+            The following properties were skipped because they were already processed in a previous run.
+            To reprocess, send from the configured override email address.
+          </p>
+          <ul style="margin: 0;">
+            ${summary
+              .skippedDuplicates!.map(
+                (d) =>
+                  `<li><strong>${this.escapeHtml(d.propertyName)}</strong> — ${this.formatDateForDisplay(d.businessDate)}</li>`,
+              )
+              .join("\n")}
+          </ul>
+        </div>
       `
       : "";
 
@@ -452,6 +477,8 @@ export class ReportEmailSender {
         ${hasPropertyDetails ? propertiesSection : `<ul>${propertiesSection}</ul>`}
       </div>
 
+      ${skippedSection}
+
       ${errorSection}
 
       <h3>Attachments</h3>
@@ -477,6 +504,8 @@ export class ReportEmailSender {
   private generateTextBody(summary: ReportSummary): string {
     const dateFormatted = this.formatDateForDisplay(summary.reportDate);
     const hasErrors = summary.errors && summary.errors.length > 0;
+    const hasSkippedDuplicates =
+      summary.skippedDuplicates && summary.skippedDuplicates.length > 0;
 
     const propertyList = summary.propertyNames
       .map((name) => `  - ${name}`)
@@ -484,6 +513,15 @@ export class ReportEmailSender {
 
     const errorSection = hasErrors
       ? `\nPROCESSING WARNINGS:\n${summary.errors.map((e) => `  ! ${e}`).join("\n")}\n`
+      : "";
+
+    const skippedSection = hasSkippedDuplicates
+      ? `\nSKIPPED (ALREADY PROCESSED):\n${summary
+          .skippedDuplicates!.map(
+            (d) =>
+              `  - ${d.propertyName} (${this.formatDateForDisplay(d.businessDate)})`,
+          )
+          .join("\n")}\n`
       : "";
 
     return `
@@ -502,7 +540,7 @@ Processing Time:     ${(summary.processingTimeMs / 1000).toFixed(2)} seconds
 PROPERTIES INCLUDED
 -------------------
 ${propertyList}
-${errorSection}
+${skippedSection}${errorSection}
 ATTACHMENTS
 -----------
 - ${summary.reportDate}_JE.csv - Journal Entry file for NetSuite import

--- a/src/lambda/file-processor.test.ts
+++ b/src/lambda/file-processor.test.ts
@@ -31,6 +31,15 @@ vi.mock("../config/environment", () => ({
   },
 }));
 vi.mock("../utils/retry");
+vi.mock("../processors/duplicate-detector", () => ({
+  DuplicateDetector: vi.fn().mockImplementation(() => ({
+    checkIfProcessed: vi.fn().mockResolvedValue({
+      isAlreadyProcessed: false,
+      markerKey: "test-marker",
+    }),
+    markAsProcessed: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
 
 const mockS3Client = {
   send: vi.fn(),
@@ -38,6 +47,7 @@ const mockS3Client = {
 
 const mockParameterStore = {
   getPropertyMapping: vi.fn(),
+  getOverrideEmails: vi.fn().mockResolvedValue([]),
 };
 
 // Mock constructors
@@ -2445,7 +2455,7 @@ Room Revenue: 500.00`;
       };
 
       // Call the internal applyAccountCodeMappings method directly
-      const consolidatedReports = await (
+      const { reports: consolidatedReports, skippedDuplicates } = await (
         processor as any
       ).applyAccountCodeMappings(
         mockFiles,
@@ -2456,6 +2466,7 @@ Room Revenue: 500.00`;
       // FIXED BEHAVIOR: Should have 3 separate reports, one for each business date
       // The keying is now by propertyId|businessDate instead of just propertyId
       expect(consolidatedReports.length).toBe(3);
+      expect(skippedDuplicates).toEqual([]);
 
       // Each report should have the correct business date
       const reportDates = consolidatedReports.map((r: any) => r.reportDate);

--- a/src/lambda/file-processor.ts
+++ b/src/lambda/file-processor.ts
@@ -37,6 +37,10 @@ import { TransformationEngine } from "../transformation/transformation-engine";
 import { JournalEntryGenerator } from "../output/journal-entry-generator";
 import { StatisticalEntryGenerator } from "../output/statistical-entry-generator";
 import { CreditCardProcessor } from "../processors/credit-card-processor";
+import {
+  DuplicateDetector,
+  type ProcessedMarkerMetadata,
+} from "../processors/duplicate-detector";
 import { getPropertyConfigService } from "../config/property-config";
 import {
   ReportEmailSender,
@@ -110,6 +114,16 @@ interface ConsolidatedReport {
 }
 
 /**
+ * A property+date combination that was skipped because it was already processed
+ */
+export interface SkippedDuplicate {
+  propertyName: string;
+  businessDate: string;
+  fileKey: string;
+  reason: "already_processed";
+}
+
+/**
  * Interface for the file processing result
  */
 interface FileProcessingResult {
@@ -122,6 +136,7 @@ interface FileProcessingResult {
     propertiesProcessed: string[];
     processingTimeMs: number;
     reportsGenerated: number;
+    skippedDuplicates: SkippedDuplicate[];
   };
 }
 
@@ -184,6 +199,7 @@ export class FileProcessor {
   private parserFactory: ParserFactory;
   private transformationEngine: TransformationEngine;
   private emailSender: ReportEmailSender;
+  private duplicateDetector: DuplicateDetector;
 
   constructor() {
     this.s3Client = new S3Client({
@@ -205,6 +221,12 @@ export class FileProcessor {
       processedBucket: this.processedBucket,
       region: environmentConfig.awsRegion,
     });
+
+    // Initialize duplicate detector for Phase 6
+    this.duplicateDetector = new DuplicateDetector(
+      this.s3Client,
+      this.processedBucket,
+    );
   }
 
   /**
@@ -287,39 +309,55 @@ export class FileProcessor {
         operation: "files_processed",
       });
 
-      // Step 4: Apply VisualMatrix account code mappings (Phase 3C)
-      const transformedData = await this.applyAccountCodeMappings(
-        processedFiles,
-        correlationId,
-        visualMatrixData, // Pass the already-loaded mapping data
-      );
+      // Step 4: Apply VisualMatrix account code mappings (Phase 3C) with duplicate detection (Phase 6)
+      const { reports: transformedData, skippedDuplicates } =
+        await this.applyAccountCodeMappings(
+          processedFiles,
+          correlationId,
+          visualMatrixData,
+        );
 
       logger.info("Data transformations applied", {
         totalRecordsTransformed: transformedData.reduce(
           (sum, p) => sum + p.totalRecords,
           0,
         ),
+        skippedDuplicatesCount: skippedDuplicates.length,
         operation: "transformations_applied",
       });
 
       // Step 5: Generate consolidated reports (Phase 3D)
-      const reports = await this.generateConsolidatedReports(
+      const reportKeys = await this.generateConsolidatedReports(
         transformedData,
         correlationId,
       );
 
       logger.info("Consolidated reports generated", {
-        reportsGenerated: reports.length,
+        reportsGenerated: reportKeys.length,
         operation: "reports_generated",
       });
+
+      // Step 5.5: Write processed markers for duplicate detection on future runs (Phase 6)
+      if (reportKeys.length >= 2) {
+        const jeReportKey = reportKeys.find((r) => r.includes("_JE.csv")) || "";
+        const statJEReportKey =
+          reportKeys.find((r) => r.includes("_StatJE.csv")) || "";
+
+        await this.writeProcessedMarkers(
+          transformedData,
+          jeReportKey,
+          statJEReportKey,
+          correlationId,
+        );
+      }
 
       const processingTimeMs = Date.now() - startTime;
 
       // Step 6: Send email with reports (Phase 5)
-      if (reports.length >= 2) {
-        const jeReportKey = reports.find((r) => r.includes("_JE.csv")) || "";
+      if (reportKeys.length >= 2) {
+        const jeReportKey = reportKeys.find((r) => r.includes("_JE.csv")) || "";
         const statJEReportKey =
-          reports.find((r) => r.includes("_StatJE.csv")) || "";
+          reportKeys.find((r) => r.includes("_StatJE.csv")) || "";
 
         if (jeReportKey && statJEReportKey) {
           // Calculate record counts from transformed data
@@ -388,6 +426,7 @@ export class FileProcessor {
             processingTimeMs,
             errors: processingErrors,
             propertyDetails,
+            skippedDuplicates,
           };
 
           const emailResult = await this.emailSender.sendReportEmail(
@@ -421,7 +460,8 @@ export class FileProcessor {
           filesFound: files.length,
           propertiesProcessed,
           processingTimeMs,
-          reportsGenerated: reports.length,
+          reportsGenerated: reportKeys.length,
+          skippedDuplicates,
         },
       };
     } catch (error) {
@@ -440,6 +480,7 @@ export class FileProcessor {
           propertiesProcessed: [],
           processingTimeMs: Date.now() - startTime,
           reportsGenerated: 0,
+          skippedDuplicates: [],
         },
       };
     }
@@ -1183,13 +1224,18 @@ export class FileProcessor {
   }
 
   /**
-   * Step 4: Apply VisualMatrix account code mappings to processed files
+   * Step 4: Apply VisualMatrix account code mappings to processed files.
+   * Includes duplicate detection (Phase 6) - skips files already processed
+   * unless sender matches the override email address.
    */
   private async applyAccountCodeMappings(
     processedFiles: ProcessedFileData[],
     correlationId: string,
     visualMatrixData?: VisualMatrixData | null,
-  ): Promise<ConsolidatedReport[]> {
+  ): Promise<{
+    reports: ConsolidatedReport[];
+    skippedDuplicates: SkippedDuplicate[];
+  }> {
     const logger = createCorrelatedLogger(correlationId, {
       operation: "apply_account_code_mappings",
     });
@@ -1203,8 +1249,11 @@ export class FileProcessor {
       logger.error(
         "No VisualMatrix mapping data available - cannot process files",
       );
-      return [];
+      return { reports: [], skippedDuplicates: [] };
     }
+
+    // Load override emails once for the entire batch (cached by Parameter Store)
+    const overrideEmails = await this.parameterStore.getOverrideEmails();
 
     // Step 4.1: Post-parse duplicate detection
     // Deduplicate based on propertyName|businessDate from PDF content
@@ -1222,6 +1271,7 @@ export class FileProcessor {
     });
 
     const reportsByProperty: { [propertyId: string]: ConsolidatedReport } = {};
+    const skippedDuplicates: SkippedDuplicate[] = [];
 
     for (const file of deduplicatedFiles) {
       if (file.errors.length > 0) {
@@ -1272,6 +1322,55 @@ export class FileProcessor {
           reportDate,
           usedFallback: !businessDate,
         });
+
+        // Phase 6: Duplicate detection
+        // Check if this property+date has already been processed in a previous run
+        const duplicateCheck = await this.duplicateDetector.checkIfProcessed(
+          propertyName,
+          reportDate,
+          correlationId,
+        );
+
+        if (duplicateCheck.isAlreadyProcessed) {
+          // Check if this file came from one of the override senders
+          const senderEmail = await this.getSenderEmailFromMetadata(
+            file.fileKey,
+            correlationId,
+          );
+          const isOverride =
+            overrideEmails.length > 0 &&
+            senderEmail !== null &&
+            overrideEmails.includes(senderEmail.toLowerCase());
+
+          if (isOverride) {
+            logger.info(
+              "Duplicate detected but override sender - reprocessing",
+              {
+                fileKey: file.fileKey,
+                propertyName,
+                reportDate,
+                senderEmail,
+                operation: "override_reprocessing",
+              },
+            );
+          } else {
+            logger.info("Duplicate detected - skipping file", {
+              fileKey: file.fileKey,
+              propertyName,
+              reportDate,
+              markerKey: duplicateCheck.markerKey,
+              operation: "duplicate_skipped",
+            });
+
+            skippedDuplicates.push({
+              propertyName,
+              businessDate: reportDate,
+              fileKey: file.fileKey,
+              reason: "already_processed",
+            });
+            continue;
+          }
+        }
 
         // Get property config
         const propertyConfigService = getPropertyConfigService();
@@ -1364,7 +1463,73 @@ export class FileProcessor {
       }
     }
 
-    return Object.values(reportsByProperty);
+    return { reports: Object.values(reportsByProperty), skippedDuplicates };
+  }
+
+  /**
+   * Write processed markers for all successfully processed property+date combinations.
+   * Called after reports are generated so the marker points to the actual report keys.
+   */
+  private async writeProcessedMarkers(
+    transformedData: ConsolidatedReport[],
+    jeReportKey: string,
+    statJEReportKey: string,
+    correlationId: string,
+  ): Promise<void> {
+    for (const report of transformedData) {
+      const metadata: ProcessedMarkerMetadata = {
+        propertyName: report.propertyName || report.propertyId,
+        businessDate: report.reportDate,
+        processedAt: new Date().toISOString(),
+        reportKeys: {
+          je: jeReportKey,
+          statJE: statJEReportKey,
+        },
+        recordCount: report.totalRecords,
+        correlationId,
+      };
+
+      await this.duplicateDetector.markAsProcessed(metadata, correlationId);
+    }
+  }
+
+  /**
+   * Retrieve the sender email address from S3 object metadata.
+   * The email processor stores senderEmail in object metadata when saving attachments.
+   * Returns null if metadata is unavailable or the file has no sender info.
+   */
+  private async getSenderEmailFromMetadata(
+    fileKey: string,
+    correlationId: string,
+  ): Promise<string | null> {
+    const logger = createCorrelatedLogger(correlationId, {
+      operation: "get_sender_email",
+      fileKey,
+    });
+
+    try {
+      const response = await this.s3Client.send(
+        new HeadObjectCommand({
+          Bucket: this.incomingBucket,
+          Key: fileKey,
+        }),
+      );
+
+      const senderEmail = response.Metadata?.senderEmail || null;
+
+      logger.debug("Retrieved sender email from S3 metadata", {
+        fileKey,
+        senderEmail,
+      });
+
+      return senderEmail;
+    } catch (error) {
+      logger.warn("Could not retrieve sender email from S3 metadata", {
+        fileKey,
+        error: (error as Error).message,
+      });
+      return null;
+    }
   }
 
   /**

--- a/src/lambda/file-processor.ts
+++ b/src/lambda/file-processor.ts
@@ -2394,6 +2394,7 @@ export class FileProcessor {
             propertiesProcessed: [],
             processingTimeMs: Date.now() - startTime,
             reportsGenerated: 0,
+            skippedDuplicates: [],
           },
         };
       }
@@ -2436,6 +2437,7 @@ export class FileProcessor {
           propertiesProcessed: [],
           processingTimeMs: Date.now() - startTime,
           reportsGenerated: 2,
+          skippedDuplicates: [],
         },
       };
     } catch (error) {
@@ -2454,6 +2456,7 @@ export class FileProcessor {
           propertiesProcessed: [],
           processingTimeMs: Date.now() - startTime,
           reportsGenerated: 0,
+          skippedDuplicates: [],
         },
       };
     }
@@ -2519,6 +2522,7 @@ export class FileProcessor {
             propertiesProcessed: [],
             processingTimeMs: Date.now() - startTime,
             reportsGenerated: 0,
+            skippedDuplicates: [],
           },
         };
       }
@@ -2578,6 +2582,7 @@ export class FileProcessor {
             propertiesProcessed: [],
             processingTimeMs: Date.now() - startTime,
             reportsGenerated: 0,
+            skippedDuplicates: [],
           },
         };
       }
@@ -2588,11 +2593,12 @@ export class FileProcessor {
         await this.loadVisualMatrixMapping(correlationId);
 
       // Apply account code mappings and transformations
-      const consolidatedReports = await this.applyAccountCodeMappings(
-        matchingFiles,
-        correlationId,
-        visualMatrixData,
-      );
+      const { reports: consolidatedReports } =
+        await this.applyAccountCodeMappings(
+          matchingFiles,
+          correlationId,
+          visualMatrixData,
+        );
 
       // Generate CSV reports
       const { jeContent, statJEContent } =
@@ -2709,6 +2715,7 @@ export class FileProcessor {
           propertiesProcessed,
           processingTimeMs: Date.now() - startTime,
           reportsGenerated: 2,
+          skippedDuplicates: [],
         },
       };
       /* c8 ignore stop */
@@ -2728,6 +2735,7 @@ export class FileProcessor {
           propertiesProcessed: [],
           processingTimeMs: Date.now() - startTime,
           reportsGenerated: 0,
+          skippedDuplicates: [],
         },
       };
     }
@@ -2858,6 +2866,7 @@ export const handler = async (
         propertiesProcessed: [],
         processingTimeMs: 0,
         reportsGenerated: 0,
+        skippedDuplicates: [],
       },
     };
   }

--- a/src/processors/duplicate-detector.test.ts
+++ b/src/processors/duplicate-detector.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi } from "vitest";
+import { S3Client } from "@aws-sdk/client-s3";
+import { DuplicateDetector } from "./duplicate-detector";
+
+// Mock the retry utility so tests don't wait for backoff delays
+vi.mock("../utils/retry", () => ({
+  retryS3Operation: vi.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
+// Mock the logger
+vi.mock("../utils/logger", () => ({
+  createCorrelatedLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+  })),
+}));
+
+const CORRELATION_ID = "test-correlation-id";
+const PROCESSED_BUCKET = "test-processed-bucket";
+
+function makeS3Client(sendImpl: (input: unknown) => unknown): S3Client {
+  return { send: vi.fn(sendImpl) } as unknown as S3Client;
+}
+
+describe("DuplicateDetector", () => {
+  describe("buildMarkerKey", () => {
+    it("sanitizes property name for S3 key", () => {
+      const detector = new DuplicateDetector(
+        makeS3Client(() => ({})),
+        PROCESSED_BUCKET,
+      );
+
+      expect(
+        detector.buildMarkerKey("Best Western Windsor Inn", "2026-02-26"),
+      ).toBe("processed-markers/2026-02-26/best-western-windsor-inn.json");
+    });
+
+    it("handles property names with special characters", () => {
+      const detector = new DuplicateDetector(
+        makeS3Client(() => ({})),
+        PROCESSED_BUCKET,
+      );
+
+      expect(
+        detector.buildMarkerKey("THE BARD'S INN HOTEL", "2026-02-26"),
+      ).toBe("processed-markers/2026-02-26/the-bard-s-inn-hotel.json");
+    });
+
+    it("strips leading and trailing hyphens", () => {
+      const detector = new DuplicateDetector(
+        makeS3Client(() => ({})),
+        PROCESSED_BUCKET,
+      );
+
+      expect(detector.buildMarkerKey("  El Bonita  ", "2026-01-15")).toBe(
+        "processed-markers/2026-01-15/el-bonita.json",
+      );
+    });
+
+    it("collapses consecutive special characters to single hyphen", () => {
+      const detector = new DuplicateDetector(
+        makeS3Client(() => ({})),
+        PROCESSED_BUCKET,
+      );
+
+      expect(detector.buildMarkerKey("BW Plus -- PONDERAY", "2026-02-01")).toBe(
+        "processed-markers/2026-02-01/bw-plus-ponderay.json",
+      );
+    });
+  });
+
+  describe("checkIfProcessed", () => {
+    it("returns false when no marker exists (404)", async () => {
+      const notFoundError = Object.assign(new Error("Not Found"), {
+        name: "NotFound",
+        $metadata: { httpStatusCode: 404 },
+      });
+      const s3Client = makeS3Client(() => {
+        throw notFoundError;
+      });
+
+      const detector = new DuplicateDetector(s3Client, PROCESSED_BUCKET);
+      const result = await detector.checkIfProcessed(
+        "Best Western Windsor Inn",
+        "2026-02-26",
+        CORRELATION_ID,
+      );
+
+      expect(result.isAlreadyProcessed).toBe(false);
+      expect(result.markerKey).toBe(
+        "processed-markers/2026-02-26/best-western-windsor-inn.json",
+      );
+    });
+
+    it("returns false when NoSuchKey error", async () => {
+      const noSuchKeyError = Object.assign(new Error("No Such Key"), {
+        name: "NoSuchKey",
+        $metadata: { httpStatusCode: 404 },
+      });
+      const s3Client = makeS3Client(() => {
+        throw noSuchKeyError;
+      });
+
+      const detector = new DuplicateDetector(s3Client, PROCESSED_BUCKET);
+      const result = await detector.checkIfProcessed(
+        "Crown City Inn",
+        "2026-02-26",
+        CORRELATION_ID,
+      );
+
+      expect(result.isAlreadyProcessed).toBe(false);
+    });
+
+    it("returns true when marker exists", async () => {
+      const s3Client = makeS3Client(() => ({
+        LastModified: new Date("2026-02-27T20:05:00Z"),
+        ContentLength: 250,
+        ContentType: "application/json",
+      }));
+
+      const detector = new DuplicateDetector(s3Client, PROCESSED_BUCKET);
+      const result = await detector.checkIfProcessed(
+        "Best Western Windsor Inn",
+        "2026-02-26",
+        CORRELATION_ID,
+      );
+
+      expect(result.isAlreadyProcessed).toBe(true);
+      expect(result.markerKey).toBe(
+        "processed-markers/2026-02-26/best-western-windsor-inn.json",
+      );
+    });
+
+    it("fails open (returns false) when S3 throws unexpected error", async () => {
+      const unexpectedError = new Error("Internal Server Error");
+      const s3Client = makeS3Client(() => {
+        throw unexpectedError;
+      });
+
+      const detector = new DuplicateDetector(s3Client, PROCESSED_BUCKET);
+      const result = await detector.checkIfProcessed(
+        "Driftwood Inn",
+        "2026-02-26",
+        CORRELATION_ID,
+      );
+
+      // Should fail open - allow processing rather than silently dropping
+      expect(result.isAlreadyProcessed).toBe(false);
+    });
+  });
+
+  describe("markAsProcessed", () => {
+    it("writes marker to correct S3 key with correct content", async () => {
+      const putObjectMock = vi.fn().mockResolvedValue({});
+      const s3Client = makeS3Client(putObjectMock);
+
+      const detector = new DuplicateDetector(s3Client, PROCESSED_BUCKET);
+      const metadata = {
+        propertyName: "Best Western Windsor Inn",
+        businessDate: "2026-02-26",
+        processedAt: "2026-02-27T20:05:00.000Z",
+        reportKeys: {
+          je: "reports/2026-02-27/2026-02-26_JE.csv",
+          statJE: "reports/2026-02-27/2026-02-26_StatJE.csv",
+        },
+        recordCount: 42,
+        correlationId: CORRELATION_ID,
+      };
+
+      await detector.markAsProcessed(metadata, CORRELATION_ID);
+
+      expect(putObjectMock).toHaveBeenCalledOnce();
+      const callArg = putObjectMock.mock.calls[0][0];
+      expect(callArg.input.Bucket).toBe(PROCESSED_BUCKET);
+      expect(callArg.input.Key).toBe(
+        "processed-markers/2026-02-26/best-western-windsor-inn.json",
+      );
+      expect(callArg.input.ContentType).toBe("application/json");
+
+      const body = JSON.parse(callArg.input.Body as string);
+      expect(body.propertyName).toBe("Best Western Windsor Inn");
+      expect(body.businessDate).toBe("2026-02-26");
+      expect(body.recordCount).toBe(42);
+      expect(body.reportKeys.je).toBe("reports/2026-02-27/2026-02-26_JE.csv");
+    });
+
+    it("does not throw if S3 write fails (fails silently)", async () => {
+      const s3Client = makeS3Client(() => {
+        throw new Error("S3 write failed");
+      });
+
+      const detector = new DuplicateDetector(s3Client, PROCESSED_BUCKET);
+      const metadata = {
+        propertyName: "Crown City Inn",
+        businessDate: "2026-02-26",
+        processedAt: "2026-02-27T20:05:00.000Z",
+        reportKeys: {
+          je: "reports/2026-02-27/2026-02-26_JE.csv",
+          statJE: "reports/2026-02-27/2026-02-26_StatJE.csv",
+        },
+        recordCount: 10,
+        correlationId: CORRELATION_ID,
+      };
+
+      // Should NOT throw even when S3 fails
+      await expect(
+        detector.markAsProcessed(metadata, CORRELATION_ID),
+      ).resolves.toBeUndefined();
+    });
+
+    it("includes S3 metadata headers with key info", async () => {
+      const putObjectMock = vi.fn().mockResolvedValue({});
+      const s3Client = makeS3Client(putObjectMock);
+
+      const detector = new DuplicateDetector(s3Client, PROCESSED_BUCKET);
+      await detector.markAsProcessed(
+        {
+          propertyName: "El Bonita Motel",
+          businessDate: "2026-02-26",
+          processedAt: "2026-02-27T20:05:00.000Z",
+          reportKeys: { je: "je.csv", statJE: "stat.csv" },
+          recordCount: 5,
+          correlationId: CORRELATION_ID,
+        },
+        CORRELATION_ID,
+      );
+
+      const callArg = putObjectMock.mock.calls[0][0];
+      expect(callArg.input.Metadata.propertyName).toBe("El Bonita Motel");
+      expect(callArg.input.Metadata.businessDate).toBe("2026-02-26");
+      expect(callArg.input.Metadata.correlationId).toBe(CORRELATION_ID);
+    });
+  });
+});

--- a/src/processors/duplicate-detector.ts
+++ b/src/processors/duplicate-detector.ts
@@ -1,0 +1,231 @@
+import {
+  S3Client,
+  HeadObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { createCorrelatedLogger } from "../utils/logger";
+import { retryS3Operation } from "../utils/retry";
+
+/**
+ * Metadata stored in the processed marker file in S3.
+ * Written after a property+date combination is successfully processed.
+ */
+export interface ProcessedMarkerMetadata {
+  propertyName: string;
+  businessDate: string;
+  processedAt: string;
+  reportKeys: {
+    je: string;
+    statJE: string;
+  };
+  recordCount: number;
+  correlationId: string;
+}
+
+/**
+ * Result of a duplicate check for a property+date combination.
+ */
+export interface DuplicateCheckResult {
+  isAlreadyProcessed: boolean;
+  markerKey: string;
+  existingMetadata?: ProcessedMarkerMetadata;
+}
+
+/**
+ * DuplicateDetector checks whether a property+date combination has already
+ * been processed by looking for a marker file in S3.
+ *
+ * Uses S3 HeadObject for O(1) lookups - constant time regardless of
+ * how many files have been processed historically.
+ *
+ * Marker files are stored at:
+ *   processed-markers/{businessDate}/{sanitizedPropertyName}.json
+ */
+export class DuplicateDetector {
+  private s3Client: S3Client;
+  private processedBucket: string;
+
+  constructor(s3Client: S3Client, processedBucket: string) {
+    this.s3Client = s3Client;
+    this.processedBucket = processedBucket;
+  }
+
+  /**
+   * Check whether a property+date combination has already been processed.
+   * Uses S3 HeadObject - fast, cheap, and scales infinitely.
+   *
+   * @param propertyName - Property name extracted from the PDF
+   * @param businessDate - Business date in YYYY-MM-DD format
+   * @param correlationId - Correlation ID for logging
+   * @returns DuplicateCheckResult indicating whether already processed
+   */
+  async checkIfProcessed(
+    propertyName: string,
+    businessDate: string,
+    correlationId: string,
+  ): Promise<DuplicateCheckResult> {
+    const logger = createCorrelatedLogger(correlationId, {
+      operation: "duplicate_check",
+      propertyName,
+      businessDate,
+    });
+
+    const markerKey = this.buildMarkerKey(propertyName, businessDate);
+
+    logger.debug("Checking for existing processed marker", {
+      bucket: this.processedBucket,
+      markerKey,
+    });
+
+    try {
+      const response = await retryS3Operation(
+        () =>
+          this.s3Client.send(
+            new HeadObjectCommand({
+              Bucket: this.processedBucket,
+              Key: markerKey,
+            }),
+          ),
+        correlationId,
+        "head_processed_marker",
+        { maxRetries: 2, baseDelay: 500 },
+      );
+
+      // Marker exists - parse metadata from the stored content-type header
+      // (full metadata is in the object body, but HeadObject gives us enough to confirm existence)
+      logger.info("Processed marker found - property already processed", {
+        markerKey,
+        lastModified: response.LastModified?.toISOString(),
+        operation: "duplicate_detected",
+      });
+
+      return {
+        isAlreadyProcessed: true,
+        markerKey,
+      };
+    } catch (error) {
+      // 404 / NoSuchKey means not yet processed - this is the expected happy path
+      if (this.isNotFoundError(error)) {
+        logger.debug("No processed marker found - property not yet processed", {
+          markerKey,
+          operation: "no_duplicate",
+        });
+
+        return {
+          isAlreadyProcessed: false,
+          markerKey,
+        };
+      }
+
+      // Any other error (permissions, network) - log and fail open (allow processing)
+      // Better to process a duplicate than to silently drop a file
+      logger.error(
+        "Error checking processed marker - failing open to allow processing",
+        error as Error,
+        {
+          markerKey,
+          operation: "duplicate_check_error",
+        },
+      );
+
+      return {
+        isAlreadyProcessed: false,
+        markerKey,
+      };
+    }
+  }
+
+  /**
+   * Write a processed marker to S3 after a property+date has been successfully processed.
+   * This marker is what future runs check to detect duplicates.
+   *
+   * @param metadata - Details about what was processed
+   * @param correlationId - Correlation ID for logging
+   */
+  async markAsProcessed(
+    metadata: ProcessedMarkerMetadata,
+    correlationId: string,
+  ): Promise<void> {
+    const logger = createCorrelatedLogger(correlationId, {
+      operation: "mark_as_processed",
+      propertyName: metadata.propertyName,
+      businessDate: metadata.businessDate,
+    });
+
+    const markerKey = this.buildMarkerKey(
+      metadata.propertyName,
+      metadata.businessDate,
+    );
+
+    logger.debug("Writing processed marker to S3", {
+      bucket: this.processedBucket,
+      markerKey,
+    });
+
+    try {
+      await retryS3Operation(
+        () =>
+          this.s3Client.send(
+            new PutObjectCommand({
+              Bucket: this.processedBucket,
+              Key: markerKey,
+              Body: JSON.stringify(metadata, null, 2),
+              ContentType: "application/json",
+              Metadata: {
+                propertyName: metadata.propertyName,
+                businessDate: metadata.businessDate,
+                processedAt: metadata.processedAt,
+                correlationId: metadata.correlationId,
+              },
+            }),
+          ),
+        correlationId,
+        "put_processed_marker",
+        { maxRetries: 3, baseDelay: 1000 },
+      );
+
+      logger.info("Processed marker written successfully", {
+        markerKey,
+        propertyName: metadata.propertyName,
+        businessDate: metadata.businessDate,
+        recordCount: metadata.recordCount,
+        operation: "marker_written",
+      });
+    } catch (error) {
+      // Log but don't throw - failure to write the marker shouldn't fail the processing run.
+      // The report was already generated and emailed; worst case is a duplicate next run.
+      logger.error(
+        "Failed to write processed marker - duplicate detection may not work for next run",
+        error as Error,
+        {
+          markerKey,
+          operation: "marker_write_error",
+        },
+      );
+    }
+  }
+
+  /**
+   * Build the S3 key for a processed marker file.
+   * Format: processed-markers/{businessDate}/{sanitizedPropertyName}.json
+   */
+  buildMarkerKey(propertyName: string, businessDate: string): string {
+    const sanitizedName = propertyName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    return `processed-markers/${businessDate}/${sanitizedName}.json`;
+  }
+
+  /**
+   * Determine if an S3 error is a "not found" response (404).
+   */
+  private isNotFoundError(error: unknown): boolean {
+    if (error instanceof Error) {
+      const name = (error as any).name || "";
+      const code = (error as any).$metadata?.httpStatusCode;
+      return name === "NotFound" || name === "NoSuchKey" || code === 404;
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## What
- Add `DuplicateDetector` service (`src/processors/duplicate-detector.ts`) that uses S3 `HeadObject` for O(1) lookups to check if a property+date combination has already been processed
- Wire duplicate detection into `file-processor.ts` — skips files already processed, writes processed markers to S3 after successful report generation
- Add override email support via Parameter Store (`/report-builder/{env}/email/override-sender`) — supports comma-separated list of emails that bypass duplicate detection for forced reprocessing
- Include skipped duplicates in email summary (HTML + plain text)
- Add `s3:HeadObject` IAM permission to Lambda policy in CDK storage construct
- Add `getOverrideEmails()` to `ParameterStoreConfig`
- Add `FRANCISCAN INN & SUITES` to `property-config.ts` with correct location (36) and subsidiary (5)
- Update `PROJECT_PLAN.md` to mark Phase 6 complete

## Why
Prevents the same property+date combination from being processed and emailed multiple times if the Lambda runs more than once in a day (e.g., manual trigger, reprocessing). Hotels need a way to force reprocessing when corrections are needed, handled via a designated override email address in Parameter Store.

The Franciscan Inn & Suites was recently onboarded and their files were landing in `unknown-property` with the wrong location ID (1 instead of 36) because they were not configured in the property config.

## Testing
- 500 unit tests passing across 20 test files
- New `DuplicateDetector` unit tests cover: marker key sanitization, 404 → not processed, marker found → already processed, fail-open on unexpected errors, marker write success, silent failure on write error
- `DuplicateDetector` mocked in `file-processor.test.ts` to isolate existing tests
- All existing tests unaffected

**Note:** The `security-scan` CI check will fail due to pre-existing `fast-xml-parser` vulnerabilities in the AWS SDK (not introduced by this PR). These are low practical risk as they only affect XML parsing of AWS API responses. This will be addressed separately in a `chore/dependency-updates` PR.

Made with [Cursor](https://cursor.com)