### PR TITLE
feat: add Choice Hotels daily report pipeline (Phase 14)

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,3 +1,1 @@
-{
-  "1120654": "tmp path traversal (GHSA-ph9p-34f9-6g65) via exceljs->tmp@0.2.5. Only exploitable when a user-controlled string is passed as tmp file prefix/postfix; we pass only S3 XLSX buffers to ExcelJS which controls any tmp usage internally. Remove once exceljs updates its tmp dependency."
-}
+{}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Receives daily hotel report emails with file attachments, parses them, transform
 - **S3 buckets** (both environments):
   - `report-builder-incoming-files-{env}-v2` — raw email attachments
   - `report-builder-processed-files-{env}-v2` — generated JE/StatJE reports
-  - `report-builder-mapping-files-{env}-v2` — Excel mapping files; Opera files go in `opera/` prefix
+  - `report-builder-mapping-files-{env}-v2` — Excel mapping files; Opera files go in `opera/` prefix; Choice files go in `choice/` prefix
 - **SSM Parameters** (production account `400534944857`):
   - `/report-builder/production/properties/email-mapping` — JSON mapping sender email → property slug
   - `/report-builder/production/properties/override-email` — if set, all reports route here instead of real recipients; NOT set in production (reports go to real recipients)
@@ -100,11 +100,18 @@ All properties are configured in `src/config/property-config.ts`. Each has:
 - `subsidiaryId` / `subsidiaryFullName` (NetSuite)
 - `locationId`, `accountingPeriod`, `recipientEmails`
 - `roomsAvailable` (Opera properties only — used for ADR/Occupancy/RevPAR)
+- `choiceMappingName` (Choice Hotels properties only — display name as it appears in the Choice mapping workbook)
 
 ### Opera Mapping
 - Loaded from the latest `.xlsx` file under `opera/` in the mapping bucket
 - Supports **dual mapping**: `Map<string, OperaMappingEntry[]>` — one `TRX_CODE` can produce multiple JE lines
 - The mapping file is uploaded manually to S3 when the hotel provides an updated version
+
+### Choice Mapping
+- Loaded from the latest `.xlsx` file under `choice/` in the mapping bucket
+- 7-column `Choice` sheet: `Src Data Code`, `Src Desc`, `Multiplier`, `Property Name`, `Glacct Code`, `Glacct Name`, `Acct Type`
+- Property-specific rows (non-blank `Property Name`) override global rows for that property
+- See `docs/choice-hotels-pipeline.md` for full format reference
 
 ---
 
@@ -122,6 +129,13 @@ See `docs/adding-a-new-property.md`.
 2. Add property config to `src/config/property-config.ts` with `roomsAvailable`
 3. Upload the Opera mapping XLSX to `opera/` prefix in both mapping buckets
 
+### Onboarding a New Choice Hotels Property
+See `docs/choice-hotels-pipeline.md` — Operations section.
+1. Add `auto_mail_delivery_system@choicehotels.com` → `__choice__` to SSM `email-mapping` (if not already present)
+2. Add `choice:{code}` → property slug to SSM `email-mapping` in both accounts
+3. Add property config to `src/config/property-config.ts` with `choiceMappingName`
+4. Upload or update the Choice mapping XLSX to `choice/` prefix in both mapping buckets
+
 ---
 
 ## 📍 Current State (as of June 2026)
@@ -134,13 +148,19 @@ See `docs/adding-a-new-property.md`.
 - **PR #184** (`chore/update-dependencies-june-2026`) — June 2026 dependency updates; may still be in CI
 - **PR #175** (`fix/pdf-parse-v2` branch) — contains only a docs update (`PROJECT_PLAN.md`); the branch name is misleading, no pdf-parse code changes were made
 - **Dependabot PRs #176–#183** — to be closed once PR #184 merges (they are all superseded by it)
+- **`feature/choice-hotels-pipeline`** — Choice Hotels pipeline (Phase 14); implementation complete, PR open for review
 
 ### Known Technical Debt
 - `pdf-parse` v2 migration blocked — see PROJECT_PLAN.md Phase 13
 - `tmp` (via `exceljs`) has a recurring high-severity advisory that keeps getting new IDs; exclusion in `.nsprc` needs to be updated each time (`1120654` as of June 2026)
 
 ### Next Feature Work
-**Phase 14 — Choice Hotels pipeline** (3 properties). Awaiting sample reports for format analysis. Do not start implementation until samples are received and analyzed. See `PROJECT_PLAN.md` Phase 14.
+**Phase 14 — Choice Hotels pipeline** (3 properties) — implementation complete on `feature/choice-hotels-pipeline`. Before deploying:
+1. Add SSM entries (`__choice__` sentinel + `choice:{code}` lookups) in both dev and prod
+2. Upload the Choice mapping XLSX to `choice/` prefix in both mapping buckets
+3. Deploy to dev, verify with live data, then production
+
+**Phase 7 — Day-to-Day Comparison Engine** — the next development phase after Phase 14 is deployed.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,27 +138,28 @@ See `docs/choice-hotels-pipeline.md` — Operations section.
 
 ---
 
-## 📍 Current State (as of June 2026)
+## 📍 Current State (as of July 2026)
 
 ### What's Live in Production
 - All 11 Visual Matrix (PDF) properties — fully operational
 - `holiday-inn-express-clover-lane` (IHG/Opera) — live since June 2026
+- Choice Hotels pipeline (3 properties) — **not yet deployed to production**; verified working in dev with hotel sign-off (see below)
 
 ### Open Branches / PRs
-- **PR #184** (`chore/update-dependencies-june-2026`) — June 2026 dependency updates; may still be in CI
-- **PR #175** (`fix/pdf-parse-v2` branch) — contains only a docs update (`PROJECT_PLAN.md`); the branch name is misleading, no pdf-parse code changes were made
-- **Dependabot PRs #176–#183** — to be closed once PR #184 merges (they are all superseded by it)
-- **`feature/choice-hotels-pipeline`** — Choice Hotels pipeline (Phase 14); implementation complete, PR open for review
+- **PR #194** (`feature/choice-hotels-pipeline`) — Choice Hotels pipeline (Phase 14). Implementation complete, CI green, **verified working in dev** including hotel-requested fixes (Deferred Revenue multiplier sign, duplicate Occy/ADR/RevPAR StatJE rows, combined Visa/MC/Discover JE row, common `Sub Name` values). Blocked on PR review/approval before merge — not yet reviewed as of this writing.
+- **Dependabot PRs #185–#193, #195** — a new batch of routine dependency bumps; consolidate into a single `chore/update-dependencies-{month-year}` branch per the Dependency Update Process above before merging any individually.
 
 ### Known Technical Debt
 - `pdf-parse` v2 migration blocked — see PROJECT_PLAN.md Phase 13
-- `tmp` (via `exceljs`) has a recurring high-severity advisory that keeps getting new IDs; exclusion in `.nsprc` needs to be updated each time (`1120654` as of June 2026)
+- `tmp` (via `exceljs`) has a recurring high-severity advisory that keeps getting new IDs; exclusion in `.nsprc` needs to be updated each time (check the current ID before assuming `1120654` is still current)
 
 ### Next Feature Work
-**Phase 14 — Choice Hotels pipeline** (3 properties) — implementation complete on `feature/choice-hotels-pipeline`. Before deploying:
-1. Add SSM entries (`__choice__` sentinel + `choice:{code}` lookups) in both dev and prod
-2. Upload the Choice mapping XLSX to `choice/` prefix in both mapping buckets
-3. Deploy to dev, verify with live data, then production
+**Phase 14 — Choice Hotels pipeline** (3 properties) — implementation complete and verified in dev on `feature/choice-hotels-pipeline` (PR #194). Remaining steps to reach production:
+1. Get PR #194 reviewed and merged to `main`
+2. Add SSM entries (`__choice__` sentinel + `choice:{code}` lookups) to the **production** `email-mapping` parameter (already present in dev)
+3. Upload the current Choice mapping XLSX to the `choice/` prefix of the **production** mapping bucket (already present in dev)
+4. Manually trigger the `deploy-production` GitHub Actions workflow (`workflow_dispatch`, `main` branch) — production deploys never run automatically on merge
+5. Verify with live data in production the same way it was verified in dev
 
 **Phase 7 — Day-to-Day Comparison Engine** — the next development phase after Phase 14 is deployed.
 
@@ -169,5 +170,6 @@ See `docs/choice-hotels-pipeline.md` — Operations section.
 When making changes that affect:
 - **Visual Matrix PDF pipeline** (email routing, PDF parsing, property config, SSM, SES): update `docs/adding-a-new-property.md`
 - **Opera / IHG pipeline** (parsers, mapping format, S3 prefix, slug config): update `docs/opera-ihg-pipeline.md` and `PROJECT_PLAN.md` Phase 12
+- **Choice Hotels pipeline** (parsers, mapping format, transformation rules, S3 prefix, ZIP/sentinel routing): update `docs/choice-hotels-pipeline.md`
 - **Project roadmap or completed phases**: update `PROJECT_PLAN.md`
 - **These working rules**: update this file (`AGENTS.md`)

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -154,20 +154,27 @@ IHG-type properties send **Opera text exports** (`trial_balance*.txt`, `stat_dmy
 - [x] CI/CD guard updated: prevents non-feature Dependabot PRs from overwriting active feature deployments in dev; `npm ci` added to deploy jobs to ensure correct Lambda bundling
 - [x] All tests passing; Opera pipeline verified against real production reports
 
-### Phase 14: Choice Hotels daily files (new pipeline) 🔜 **[UPCOMING]**
+### Phase 14: Choice Hotels daily files (new pipeline) ✅ **[COMPLETE — pending deploy]**
 
-3 properties send **Choice Hotels** reports. Sample reports are pending receipt and analysis. This section will be updated once samples are reviewed.
+3 properties send **Choice Hotels** Night Audit reports as ZIP attachments from the shared address `AUTO_MAIL_DELIVERY_SYSTEM@choicehotels.com`. The full pipeline is implemented and tested; the feature branch is open for review before production deployment.
 
-- [ ] Receive and analyze sample Choice Hotels report files
-- [ ] Document file format, structure, and data fields
-- [ ] Define mapping strategy (new mapping workbook or extension of existing)
-- [ ] Design parser(s) for Choice format
-- [ ] Define routing/detection logic in `FileProcessor`
-- [ ] Build JE and StatJE output from Choice data
-- [ ] Configure the 3 Choice properties in `property-config.ts`
-- [ ] Add sender emails to SSM `email-mapping` for all 3 properties
-- [ ] End-to-end testing with real sample data
-- [ ] Deploy to dev, verify, then production
+**Properties**: Comfort Inn - Missoula (MT118), Comfort Inn & Suites - Ashland (OR258), Comfort Inn & Suites - Spokane Valley (WA244).
+
+- [x] Receive and analyze sample Choice Hotels report files
+- [x] Document file format, structure, and data fields
+- [x] Define mapping strategy — new `choice/` S3 prefix with 7-column `Choice` sheet XLSX
+- [x] Design parsers — `choice-journal-summary-parser.ts` and `choice-hotel-stats-parser.ts`
+- [x] Define routing/detection logic — `getChoiceFileType` + `processChoiceFilePairs` in `file-processor.ts`; `processZipAttachment` + `resolvePropertySlugForZip` in `email-processor.ts`
+- [x] Build JE and StatJE output — `choice-transformation.ts` using existing `JournalEntryGenerator` / `StatisticalEntryGenerator`
+- [x] Configure the 3 Choice properties in `property-config.ts` with `choiceMappingName`
+- [x] ZIP extraction via `adm-zip` in `email-processor`
+- [x] Shared-sender routing via `__choice__` SSM sentinel + `choice:{code}` property-code lookup
+- [x] Missing-file warning in summary email (`missingChoiceFiles`)
+- [x] Full unit test coverage; all thresholds maintained
+- [ ] Add sender addresses + `choice:{code}` entries to SSM `email-mapping` in dev and prod accounts
+- [ ] Upload the Choice mapping XLSX to `choice/` prefix in both mapping buckets
+- [ ] Deploy to dev, verify with live data, then production
+- [ ] See `docs/choice-hotels-pipeline.md` for full technical reference
 
 ### Phase 7: Day-to-Day Comparison Engine
 - [ ] Enhanced S3 storage structure for processed daily data
@@ -377,7 +384,7 @@ Enhanced S3 Structure:
 - **Visual Matrix / PDF pipeline**: Phases 3–6, 8 (partial), 10 complete; production in use for all existing properties.
 - **IHG / Opera pipeline (Phase 12)**: Complete and live in production for `holiday-inn-express-clover-lane`.
 - **Dependencies**: All packages updated to latest (except `pdf-parse` — v2 migration blocked, see Phase 13).
-- **Next**: Phase 14 — Choice Hotels pipeline (3 properties). Awaiting sample reports for analysis.
+- **Phase 14 (Choice Hotels pipeline)**: Implementation complete on `feature/choice-hotels-pipeline`. Awaiting SSM configuration in dev/prod and mapping file upload before deployment.
 
 ### Phase-Based Branch Strategy
 1. **`feat/file-processing-engine`** ← **MERGED / PRODUCTION BASE ✅**

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -171,9 +171,15 @@ IHG-type properties send **Opera text exports** (`trial_balance*.txt`, `stat_dmy
 - [x] Shared-sender routing via `__choice__` SSM sentinel + `choice:{code}` property-code lookup
 - [x] Missing-file warning in summary email (`missingChoiceFiles`)
 - [x] Full unit test coverage; all thresholds maintained
-- [ ] Add sender addresses + `choice:{code}` entries to SSM `email-mapping` in dev and prod accounts
-- [ ] Upload the Choice mapping XLSX to `choice/` prefix in both mapping buckets
-- [ ] Deploy to dev, verify with live data, then production
+- [x] Add sender addresses + `choice:{code}` entries to SSM `email-mapping` in dev account
+- [x] Upload the Choice mapping XLSX to `choice/` prefix in dev mapping bucket
+- [x] Deploy to dev, verify with live data
+- [x] Bug fixes found during dev verification: `adm-zip` excluded from ESM Lambda bundling, override-sender routing for Choice ZIPs, `choice/` prefix excluded from VisualMatrix mapping file scan, filename detection matches sanitized (underscore) filenames
+- [x] Hotel feedback fixes (July 2026), verified working in dev: Deferred Revenue (`24000-263`) multiplier sign, duplicate zero-value Occy/ADR/RevPAR StatJE rows removed, Visa/MC/Discover combined into one JE row, `Sub Name` updated to common hotel names
+- [ ] Add sender addresses + `choice:{code}` entries to SSM `email-mapping` in **production** account
+- [ ] Upload the Choice mapping XLSX to `choice/` prefix in **production** mapping bucket
+- [ ] Get PR #194 reviewed/approved and merged to `main`
+- [ ] Manually trigger `deploy-production` workflow, then verify with live data in production
 - [ ] See `docs/choice-hotels-pipeline.md` for full technical reference
 
 ### Phase 7: Day-to-Day Comparison Engine
@@ -447,10 +453,10 @@ Enhanced S3 Structure:
 6. **✅ COMPLETED**: Phase 12 - IHG / Opera pipeline live in production
 7. **✅ COMPLETED**: Dependency updates — all packages to latest; audit threshold raised to `high`
 8. **⏸ BLOCKED**: `pdf-parse` v2 migration — needs dedicated investigation (see Phase 13)
-9. **NEXT**: Phase 14 - Choice Hotels pipeline (3 properties)
-   - Awaiting sample reports for format analysis
-   - Will follow same pattern as Phase 12 (Opera)
-10. **FUTURE**: Phase 7 - Day-to-Day Comparison Engine
+9. **✅ COMPLETE — pending prod deploy**: Phase 14 - Choice Hotels pipeline (3 properties)
+   - Implemented, tested, and verified in dev with hotel sign-off on PR #194
+   - Remaining: PR review/merge, production SSM + mapping upload, manual prod deploy trigger
+10. **NEXT**: Phase 7 - Day-to-Day Comparison Engine
     - Historical data storage and retrieval system
     - Delta calculation algorithms for day-over-day changes
     - Enhanced reporting with change summaries

--- a/docs/architecture.json
+++ b/docs/architecture.json
@@ -1,8 +1,8 @@
 {
   "project": "report-builder",
   "description": "Automated hotel report processing system. Receives daily report emails, parses and transforms the data using GL account mappings, and delivers JE and StatJE CSV reports to accounting.",
-  "version": "0.9.2",
-  "lastUpdated": "2026-06-16",
+  "version": "0.10.0",
+  "lastUpdated": "2026-06-24",
   "environments": {
     "development": {
       "awsAccountId": "237124340260",
@@ -33,10 +33,10 @@
       },
       {
         "id": "hotel_email_choice",
-        "name": "Choice Hotels (Upcoming)",
-        "type": "external_future",
-        "description": "3 properties — Phase 14, awaiting sample reports",
-        "details": "Format unknown, pending sample report analysis"
+        "name": "Choice Hotels",
+        "type": "external",
+        "description": "3 properties (Comfort Inn Missoula MT118, Comfort Inn & Suites Ashland OR258, Comfort Inn & Suites Spokane Valley WA244)",
+        "details": "Sends two CSV files per day wrapped in a ZIP attachment from AUTO_MAIL_DELIVERY_SYSTEM@choicehotels.com. Files: Hotel Statistics_*.csv and Hotel Journal Summary_*.csv. Property code is embedded in ZIP filename (e.g. All_Night_Audit_Reports_WA244_HOTEL STATS_2026-06-23.zip). Implementation complete in feature/choice-hotels-pipeline — pending SSM configuration and deployment."
       },
       {
         "id": "netsuite",
@@ -91,7 +91,7 @@
         "type": "aws_s3",
         "bucketName": "report-builder-mapping-files-{env}-v2",
         "description": "Stores Excel mapping workbooks for GL account transformation",
-        "structure": "VisualMatrix XLSX at root level; Opera XLSX under opera/ prefix"
+        "structure": "VisualMatrix XLSX at root level; Opera XLSX under opera/ prefix; Choice Hotels XLSX under choice/ prefix"
       },
       {
         "id": "lambda_email",
@@ -104,7 +104,8 @@
           "Parse raw email via mailparser",
           "Identify property from sender email via SSM email-mapping parameter",
           "Store attachments to S3 incoming-files bucket with unique UUID filename",
-          "Handles duplicate file prevention via UUID in filename"
+          "Handles duplicate file prevention via UUID in filename",
+          "Extracts CSV files from ZIP attachments (Choice Hotels); routes via __choice__ sentinel + choice:{code} SSM lookup"
         ]
       },
       {
@@ -118,7 +119,7 @@
           "Discover all files in S3 incoming-files from last 24 hours",
           "Group files by property slug",
           "Check for duplicates via S3 processed-markers",
-          "Route to Visual Matrix or Opera pipeline based on filename pattern",
+          "Route to Visual Matrix, Opera, or Choice Hotels pipeline based on filename pattern",
           "Load appropriate mapping file from S3",
           "Parse, transform, and generate JE and StatJE CSV reports",
           "Store reports in S3 processed-files",
@@ -302,15 +303,32 @@
     {
       "id": "choice_hotels",
       "name": "Choice Hotels Pipeline",
-      "status": "upcoming",
+      "status": "implemented — pending deployment",
       "propertyCount": 3,
       "phase": 14,
-      "notes": "Awaiting sample reports. Format unknown. Will follow same pattern as Opera pipeline."
+      "properties": ["comfort-inn-missoula", "comfort-inn-suites-ashland", "comfort-inn-suites-spokane-valley"],
+      "triggerPattern": "Files named Hotel Statistics_*.csv AND Hotel Journal Summary_*.csv for same property+date (extracted from ZIP)",
+      "steps": [
+        "Choice Hotels sends one email per property per day from AUTO_MAIL_DELIVERY_SYSTEM@choicehotels.com with a ZIP attachment",
+        "ZIP filename contains property code, e.g. All_Night_Audit_Reports_WA244_HOTEL STATS_2026-06-23.zip",
+        "SES receipts → email-processor sees sender mapped to __choice__ sentinel",
+        "email-processor extracts property code from ZIP filename, resolves slug via choice:{code} SSM lookup",
+        "adm-zip extracts CSV files from ZIP; each stored individually under daily-files/{propertySlug}/",
+        "EventBridge triggers file-processor at 1 PM MST",
+        "file-processor detects Choice files by filename pattern, pairs hotel-statistics + journal-summary files",
+        "Raw CSV content bypasses csv-parser and is fed directly to ChoiceJournalSummaryParser / ChoiceHotelStatsParser",
+        "ChoiceMappingLoader loads latest XLSX from S3 mapping-files/choice/ prefix",
+        "transformJournalSummaryToJERecords builds JE lines (Transaction Code + ledger column sums)",
+        "transformHotelStatsToStatJERecords builds StatJE lines (column header matching, RevPAR date resolution, 3 trailing zero rows)",
+        "JE and StatJE CSV files written to S3 processed-files",
+        "SES sends reports to property recipients"
+      ]
     }
   ],
   "dataFlows": [
     { "from": "hotel_email_vm", "to": "ses_inbound", "label": "Daily PDF email" },
     { "from": "hotel_email_opera", "to": "ses_inbound", "label": "Daily TXT email (2 files)" },
+    { "from": "hotel_email_choice", "to": "ses_inbound", "label": "Daily ZIP email (2 CSVs inside)" },
     { "from": "ses_inbound", "to": "s3_incoming", "label": "Raw email stored" },
     { "from": "ses_inbound", "to": "lambda_email", "label": "Lambda trigger" },
     { "from": "lambda_email", "to": "ssm", "label": "Read email-mapping" },

--- a/docs/choice-hotels-pipeline.md
+++ b/docs/choice-hotels-pipeline.md
@@ -1,0 +1,107 @@
+# Choice Hotels pipeline (technical design)
+
+This document describes the inbound file types, mapping workbook, and implementation details for properties whose PMS sends **Choice Hotels daily Night Audit reports** as ZIP attachments.
+
+It is **not** the checklist for onboarding a PDF pipeline property—that lives in **`docs/adding-a-new-property.md`**.
+
+---
+
+## Reference materials (file formats)
+
+| Role | Example filename (inside ZIP) | What it is |
+|------|-------------------------------|------------|
+| Daily inbound — accounting | `Hotel Journal Summary_2026-06-14.csv` | Transaction-level CSV with columns including `Transaction Code`, `Totals`, `Guest Ledger`, `AR Ledger`, `AdvDep Ledger`, and many more. Most JE amounts come from the `Totals` column; the three ledger columns are summed across all rows. |
+| Daily inbound — statistics | `Hotel Statistics_2026-06-14.csv` | Single-row CSV (plus a header row) where each column represents an occupancy statistic. Column header names match the mapping's `Src Data Code` keys. The RevPAR column header changes daily: `Occupancy Statistics_RevPar_{M/D/YYYY}`. |
+| ZIP wrapper | `All_Night_Audit_Reports_WA244_HOTEL STATS_2026-06-23.zip` | Both CSV files arrive in a single ZIP per property per day, emailed from the shared address `AUTO_MAIL_DELIVERY_SYSTEM@choicehotels.com`. |
+| Target output (NetSuite JE) | `2026-06-14_JE.csv` | Same JE CSV shape as all other pipelines: `Entry`, `Date`, `Sub Name`, `Subsidiary`, `acctnumber`, `internal id`, `location`, `account name`, `Debit`, `Credit`, `Comment`, `Payment Type`. |
+| Target output (NetSuite StatJE) | `2026-06-14_StatJE.csv` | Same StatJE CSV shape as all other pipelines. Three trailing zero-value rows (Occy, ADR, RevPAR) are always appended after the main stat rows. |
+| **Choice → NetSuite mapping** | `choice-mapping.xlsx` | Excel workbook on S3 under the `choice/` prefix. The newest file (by `LastModified`) is always used. See [Choice mapping workbook](#choice-mapping-workbook) below. |
+
+---
+
+## Choice mapping workbook
+
+The workbook contains a single sheet named **`Choice`** with the following seven columns:
+
+| # | Column | Description |
+|---|--------|-------------|
+| 1 | `Src Data Code` | Source lookup key — matches a `Transaction Code` value in the Journal Summary, a ledger column name (`Guest Ledger`, `AR Ledger`, `AdvDep Ledger`), or a column header from the Hotel Statistics file. For RevPAR the key is `Occupancy Statistics_RevPar_(Date)` where `(Date)` is a literal placeholder. |
+| 2 | `Src Desc` | Human-readable description for the mapping entry. |
+| 3 | `Multiplier` | Numeric multiplier applied to the source amount before writing to NetSuite (typically `1` or `-1`). |
+| 4 | `Property Name` | When blank/null → **global** entry (applies to all properties). When non-blank → **property-specific override** that takes precedence over the global entry for that property. Match is done against `PropertyConfig.choiceMappingName`. |
+| 5 | `Glacct Code` | NetSuite account number (e.g. `40110-634`). Empty string is treated as `Not Mapped` and the row is skipped. |
+| 6 | `Glacct Name` | NetSuite account name. |
+| 7 | `Acct Type` | `Accounting` → JE record; `Statistical` → StatJE record. |
+
+**RevPAR date resolution:** The `(Date)` placeholder in the `Src Data Code` for RevPAR is matched against the actual date-stamped column header in the Hotel Statistics file using the `REVPAR_HEADER_PREFIX` constant (`Occupancy Statistics_RevPar_`).
+
+**Lookup precedence:** property-specific entry → global entry → `undefined` (row skipped).
+
+---
+
+## Inbound ZIP routing
+
+All three Choice Hotels properties share a single sender address: `AUTO_MAIL_DELIVERY_SYSTEM@choicehotels.com`.
+
+### SSM email-mapping entries (both dev and prod)
+
+| Key | Value |
+|-----|-------|
+| `auto_mail_delivery_system@choicehotels.com` | `__choice__` (sentinel) |
+| `choice:mt118` | `comfort-inn-missoula` |
+| `choice:or258` | `comfort-inn-suites-ashland` |
+| `choice:wa244` | `comfort-inn-suites-spokane-valley` |
+
+### Routing flow (email-processor)
+
+1. SES delivers the email; `email-processor` sees the sender mapped to `__choice__`.
+2. The ZIP attachment filename (e.g. `All_Night_Audit_Reports_WA244_HOTEL STATS_2026-06-23.zip`) is matched against `CHOICE_ZIP_CODE_PATTERN` to extract `WA244`.
+3. A second SSM lookup using `choice:wa244` resolves the property slug.
+4. `adm-zip` extracts each document entry from the ZIP; non-document files and directory entries are skipped.
+5. Each valid CSV is stored individually under `daily-files/{propertySlug}/{date}/` in the incoming S3 bucket with `sourceZip` metadata.
+
+---
+
+## Properties
+
+| Property slug | Choice property code | NetSuite subsidiary ID | NetSuite location ID | choiceMappingName |
+|---------------|---------------------|------------------------|----------------------|-------------------|
+| `comfort-inn-missoula` | MT118 | 37 | 21 | `Comfort Inn - Missoula` |
+| `comfort-inn-suites-ashland` | OR258 | 28 | 22 | `Comfort Inn & Suites - Ashland` |
+| `comfort-inn-suites-spokane-valley` | WA244 | 30 | 23 | `Comfort Inn & Suites - Spokane Valley` |
+
+---
+
+## End-to-end processing flow
+
+1. **Email received** — SES delivers the daily Night Audit email from `AUTO_MAIL_DELIVERY_SYSTEM@choicehotels.com` to the inbound SES rule.
+2. **email-processor Lambda** — Recognises the Choice sentinel, extracts both CSVs from the ZIP, stores them under the property slug.
+3. **file-processor Lambda** (1 PM MST EventBridge trigger) — Detects Choice files by filename pattern (`Hotel Statistics_*.csv`, `Hotel Journal Summary_*.csv`); bypasses the standard `csv-parser` and feeds raw UTF-8 content to the Choice parsers directly.
+4. **Pairing** — `processChoiceFilePairs` matches the `hotel-statistics` and `journal-summary` files for each property + date. If either file is missing, a `MissingChoiceFile` warning is included in the summary email.
+5. **Transformation** — `transformJournalSummaryToJERecords` maps `Transaction Code` values (and the three ledger column sums) to NetSuite GL lines. `transformHotelStatsToStatJERecords` maps Hotel Statistics columns to StatJE lines, then appends three trailing zero-value rows (Occy, ADR, RevPAR).
+6. **Output** — `JournalEntryGenerator` and `StatisticalEntryGenerator` write the CSVs to the processed S3 bucket; `ReportEmailSender` emails the reports to the configured recipients.
+
+---
+
+## Source modules
+
+| Module | Location |
+|--------|----------|
+| Journal Summary parser | `src/choice/choice-journal-summary-parser.ts` |
+| Hotel Statistics parser | `src/choice/choice-hotel-stats-parser.ts` |
+| Mapping loader | `src/choice/choice-mapping-loader.ts` |
+| Transformation | `src/choice/choice-transformation.ts` |
+| Barrel export | `src/choice/index.ts` |
+| ZIP routing (email-processor) | `src/lambda/email-processor.ts` — `processZipAttachment`, `resolvePropertySlugForZip` |
+| File detection & pairing (file-processor) | `src/lambda/file-processor.ts` — `getChoiceFileType`, `processChoiceFilePairs` |
+
+---
+
+## Operations — onboarding a new Choice Hotels property
+
+1. Add the sender address sentinel to SSM `email-mapping` in **both** dev and prod accounts (if not already present):
+   - `auto_mail_delivery_system@choicehotels.com` → `__choice__`
+2. Add the `choice:{code}` → slug entry to SSM `email-mapping` in both accounts (e.g. `choice:xx000` → `my-new-property`).
+3. Add the property config to `src/config/property-config.ts` with the correct `subsidiaryInternalId`, `locationInternalId`, and `choiceMappingName`.
+4. Ensure the Choice mapping XLSX in the `choice/` prefix of both mapping buckets includes rows for the new property (property-specific overrides where needed).
+5. Deploy to dev, verify, then deploy to prod.

--- a/docs/choice-hotels-pipeline.md
+++ b/docs/choice-hotels-pipeline.md
@@ -13,8 +13,8 @@ It is **not** the checklist for onboarding a PDF pipeline property—that lives 
 | Daily inbound — accounting | `Hotel Journal Summary_2026-06-14.csv` | Transaction-level CSV with columns including `Transaction Code`, `Totals`, `Guest Ledger`, `AR Ledger`, `AdvDep Ledger`, and many more. Most JE amounts come from the `Totals` column; the three ledger columns are summed across all rows. |
 | Daily inbound — statistics | `Hotel Statistics_2026-06-14.csv` | Single-row CSV (plus a header row) where each column represents an occupancy statistic. Column header names match the mapping's `Src Data Code` keys. The RevPAR column header changes daily: `Occupancy Statistics_RevPar_{M/D/YYYY}`. |
 | ZIP wrapper | `All_Night_Audit_Reports_WA244_HOTEL STATS_2026-06-23.zip` | Both CSV files arrive in a single ZIP per property per day, emailed from the shared address `AUTO_MAIL_DELIVERY_SYSTEM@choicehotels.com`. |
-| Target output (NetSuite JE) | `2026-06-14_JE.csv` | Same JE CSV shape as all other pipelines: `Entry`, `Date`, `Sub Name`, `Subsidiary`, `acctnumber`, `internal id`, `location`, `account name`, `Debit`, `Credit`, `Comment`, `Payment Type`. |
-| Target output (NetSuite StatJE) | `2026-06-14_StatJE.csv` | Same StatJE CSV shape as all other pipelines. Three trailing zero-value rows (Occy, ADR, RevPAR) are always appended after the main stat rows. |
+| Target output (NetSuite JE) | `2026-06-14_JE.csv` | Same JE CSV shape as all other pipelines: `Entry`, `Date`, `Sub Name`, `Subsidiary`, `acctnumber`, `internal id`, `location`, `account name`, `Debit`, `Credit`, `Comment`, `Payment Type`. `Sub Name` uses the common hotel name (e.g. `Comfort Inn Missoula`), not the full legal subsidiary name. |
+| Target output (NetSuite StatJE) | `2026-06-14_StatJE.csv` | Same StatJE CSV shape as all other pipelines. A trailing zero-value row (Occy, ADR, or RevPAR) is appended **only if** a real value for that GL code wasn't already emitted — see [Transformation rules](#transformation-rules) below. |
 | **Choice → NetSuite mapping** | `choice-mapping.xlsx` | Excel workbook on S3 under the `choice/` prefix. The newest file (by `LastModified`) is always used. See [Choice mapping workbook](#choice-mapping-workbook) below. |
 
 ---
@@ -36,6 +36,24 @@ The workbook contains a single sheet named **`Choice`** with the following seven
 **RevPAR date resolution:** The `(Date)` placeholder in the `Src Data Code` for RevPAR is matched against the actual date-stamped column header in the Hotel Statistics file using the `REVPAR_HEADER_PREFIX` constant (`Occupancy Statistics_RevPar_`).
 
 **Lookup precedence:** property-specific entry → global entry → `undefined` (row skipped).
+
+**Mapping file discovery:** `file-processor`'s Visual Matrix mapping loader (`loadVisualMatrixMapping`) explicitly excludes the `choice/` and `opera/` prefixes when scanning the mapping bucket for the newest `.xlsx`/`.xls`/`.csv` file. Without that exclusion, uploading a Choice mapping file can be picked up as the Visual Matrix mapping (whichever file has the newest `LastModified` wins), which breaks all Visual Matrix report processing with a `Sheet "VisualMatrix" not found` error. If a fourth mapping type is ever added, its prefix must be added to that same exclusion list.
+
+---
+
+## Transformation rules
+
+Implemented in `src/choice/choice-transformation.ts`.
+
+### Combined Visa/MasterCard/Discover row (JE)
+
+`VI`, `MC`, and `DS` transaction codes are combined into a single `"Visa/MC/Discover"` JE line (mirroring the existing convention in `credit-card-processor.ts` for Visual Matrix and `opera-transformation.ts` for Opera) so the hotel's accounting system can auto-match the combined amount to the bank deposit. American Express (`AX`) is always kept on its own line.
+
+Combining only happens when **2 or more** of the three codes are present in the Journal Summary file **and** they all resolve to the same GL account for the property. If either condition fails (e.g. only one of the three codes appears that day, or they map to different accounts), each code falls back to its own row — the combining logic can never silently merge amounts into the wrong account. If the combined amount nets to exactly zero, no row is emitted at all.
+
+### Conditional trailing StatJE rows
+
+Occy (`90002-419`), ADR (`90001-418`), and RevPAR (`90003-420`) are required placeholder rows for the NetSuite StatJE import — but the mapping normally provides real values for all three every day. A trailing zero-value row is appended for one of these three GL codes **only if** a real (mapped) value for that exact GL code wasn't already emitted earlier in the same run. This is a safety net for a missing mapping/stats column, not a row that should ever duplicate a real value — a previous version of this logic always appended all three, which produced duplicate zero-value Occy/ADR/RevPAR rows alongside the real ones (fixed July 2026 after hotel feedback).
 
 ---
 
@@ -60,6 +78,14 @@ All three Choice Hotels properties share a single sender address: `AUTO_MAIL_DEL
 4. `adm-zip` extracts each document entry from the ZIP; non-document files and directory entries are skipped.
 5. Each valid CSV is stored individually under `daily-files/{propertySlug}/{date}/` in the incoming S3 bucket with `sourceZip` metadata.
 
+### Override-sender bypass
+
+Senders listed in the `email/override-sender` SSM parameter (used to bypass duplicate-detection for testing/reprocessing) can forward a Choice Hotels ZIP from their own email address without needing `__choice__` mapped for that address. `resolvePropertySlugForZip` checks whether the sender is on the override list **and** the ZIP filename matches `CHOICE_ZIP_CODE_PATTERN` before falling through to filename-based Choice routing; otherwise a non-Choice ZIP from an override sender is routed by the sender's own mapped slug as usual.
+
+### `adm-zip` Lambda bundling
+
+`adm-zip` uses CommonJS `require("fs")` internally, which is incompatible with the `email-processor` Lambda's ESM bundling. It must be listed in `nodeModules` in `infrastructure/lib/constructs/lambda-construct.ts` so it's installed as a separate dependency rather than bundled — removing it from that list will break `email-processor` in a way that isn't caught by unit tests (it only surfaces as a runtime `Dynamic require of "fs" is not supported` error).
+
 ---
 
 ## Properties
@@ -76,9 +102,9 @@ All three Choice Hotels properties share a single sender address: `AUTO_MAIL_DEL
 
 1. **Email received** — SES delivers the daily Night Audit email from `AUTO_MAIL_DELIVERY_SYSTEM@choicehotels.com` to the inbound SES rule.
 2. **email-processor Lambda** — Recognises the Choice sentinel, extracts both CSVs from the ZIP, stores them under the property slug.
-3. **file-processor Lambda** (1 PM MST EventBridge trigger) — Detects Choice files by filename pattern (`Hotel Statistics_*.csv`, `Hotel Journal Summary_*.csv`); bypasses the standard `csv-parser` and feeds raw UTF-8 content to the Choice parsers directly.
+3. **file-processor Lambda** (1 PM MST EventBridge trigger) — Detects Choice files by filename pattern via `getChoiceFileType` (`Hotel Statistics_*.csv`, `Hotel Journal Summary_*.csv`); bypasses the standard `csv-parser` and feeds raw UTF-8 content to the Choice parsers directly. The regex matches **both spaces and underscores** between words (`hotel[ _]statistics`, `hotel[ _]journal[ _]summary`), because `email-processor`'s `sanitizeFilename()` replaces spaces with underscores before the file is stored in S3 — matching on spaces only would cause every Choice file to go undetected and be silently skipped.
 4. **Pairing** — `processChoiceFilePairs` matches the `hotel-statistics` and `journal-summary` files for each property + date. If either file is missing, a `MissingChoiceFile` warning is included in the summary email.
-5. **Transformation** — `transformJournalSummaryToJERecords` maps `Transaction Code` values (and the three ledger column sums) to NetSuite GL lines. `transformHotelStatsToStatJERecords` maps Hotel Statistics columns to StatJE lines, then appends three trailing zero-value rows (Occy, ADR, RevPAR).
+5. **Transformation** — `transformJournalSummaryToJERecords` maps `Transaction Code` values (and the three ledger column sums) to NetSuite GL lines, combining Visa/MasterCard/Discover into one row where applicable. `transformHotelStatsToStatJERecords` maps Hotel Statistics columns to StatJE lines, then appends a trailing zero-value row for any of Occy/ADR/RevPAR that wasn't already covered by a real value. See [Transformation rules](#transformation-rules) above for both.
 6. **Output** — `JournalEntryGenerator` and `StatisticalEntryGenerator` write the CSVs to the processed S3 bucket; `ReportEmailSender` emails the reports to the configured recipients.
 
 ---

--- a/infrastructure/lib/constructs/lambda-construct.ts
+++ b/infrastructure/lib/constructs/lambda-construct.ts
@@ -256,7 +256,7 @@ export class LambdaConstruct extends Construct {
       projectRoot: path.join(__dirname, '..', '..', '..'),
       depsLockFilePath: path.join(__dirname, '..', '..', '..', 'package-lock.json'),
       bundling: {
-        nodeModules: ['mailparser'],
+        nodeModules: ['mailparser', 'adm-zip'],
         externalModules: ['@aws-sdk/*'],
         format: lambdaNodejs.OutputFormat.ESM,
         target: 'es2022',

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,15 @@
         "@aws-sdk/client-ssm": "^3.1070.0",
         "@types/aws-lambda": "^8.10.161",
         "@types/pdf-parse": "^1.1.5",
+        "adm-zip": "^0.5.17",
         "exceljs": "^4.4.0",
-        "mailparser": "^3.9.10",
+        "mailparser": "^3.9.11",
         "pdf-parse": "^1.1.1"
       },
       "devDependencies": {
         "@commitlint/config-conventional": "^20.4.4",
         "@eslint/js": "^10.0.1",
+        "@types/adm-zip": "^0.5.8",
         "@types/mailparser": "^3.4.6",
         "@types/node": "^25.9.2",
         "@typescript-eslint/eslint-plugin": "^8.61.1",
@@ -1518,6 +1520,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
@@ -2022,6 +2034,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/ajv": {
@@ -3836,9 +3857,9 @@
       }
     },
     "node_modules/mailparser": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.10.tgz",
-      "integrity": "sha512-/PWScCewV4/97Y0wDNgQkcQ4FK8AK0aGVPAg51lVyisiRep9BkzkzT3/l/7aSkQ1k2T1iJu1tdXVF84wjGdDqw==",
+      "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.11.tgz",
+      "integrity": "sha512-N1LPZwp1yVblJQukv5NAedlkHeA+PmZYdPCfk0Uwohn8JFOM8fYoUGF978qwlQcd3AlUleuzK0fu/EFAHPM9tg==",
       "license": "MIT",
       "dependencies": {
         "@zone-eu/mailsplit": "5.4.12",
@@ -3848,7 +3869,7 @@
         "iconv-lite": "0.7.2",
         "libmime": "5.3.8",
         "linkify-it": "5.0.1",
-        "nodemailer": "9.0.0",
+        "nodemailer": "9.0.1",
         "punycode.js": "2.3.1",
         "tlds": "1.261.0"
       }
@@ -3978,9 +3999,9 @@
       "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw=="
     },
     "node_modules/nodemailer": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.0.tgz",
-      "integrity": "sha512-tbPTid7d/p9jAA8CRZ3iomvrMaST0o6NYuY7v6JQZHpPRZ61mLFSPKYd7342NtOFuej9/+L48SOIxwfu2uDvtw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
         "@aws-sdk/client-ssm": "^3.1070.0",
         "@types/aws-lambda": "^8.10.161",
         "@types/pdf-parse": "^1.1.5",
-        "adm-zip": "^0.5.17",
+        "adm-zip": "^0.6.0",
         "exceljs": "^4.4.0",
-        "mailparser": "^3.9.11",
+        "mailparser": "^3.9.14",
         "pdf-parse": "^1.1.1"
       },
       "devDependencies": {
@@ -2003,13 +2003,13 @@
       }
     },
     "node_modules/@zone-eu/mailsplit": {
-      "version": "5.4.12",
-      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.12.tgz",
-      "integrity": "sha512-w7Gy+NvjZ0MiXm8F6zfjImAqcTONKDImgWVBjDKQVFUXWuz3VFM5levNArkL2M877ajql5+bkS2pDV56injlmg==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.14.tgz",
+      "integrity": "sha512-rz0FQOhN3Vq1XrSeSSa9+dPcaFbBxmQPjiZm6zS9oxdVHV7rOWIAYX3yP2YAUf0qBncY8CI+NogzPCmMVrMXcw==",
       "license": "(MIT OR EUPL-1.1+)",
       "dependencies": {
         "libbase64": "1.3.0",
-        "libmime": "5.3.8",
+        "libmime": "5.4.1",
         "libqp": "2.1.1"
       }
     },
@@ -2037,12 +2037,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/ajv": {
@@ -2242,9 +2242,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2586,6 +2586,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
       "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.10.0"
       }
@@ -3426,24 +3427,25 @@
     "node_modules/libbase64": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
-      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg=="
+      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
+      "license": "MIT"
     },
     "node_modules/libmime": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.8.tgz",
-      "integrity": "sha512-ZrCY+Q66mPvasAfjsQ/IgahzoBvfE1VdtGRpo1hwRB1oK3wJKxhKA3GOcd2a6j7AH5eMFccxK9fBoCpRZTf8ng==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.4.1.tgz",
+      "integrity": "sha512-0wHGhsofo9IdQPenr3BBHXuxcwMq4atFUTsZ9Ogc1OvI5h4rUdDIrBQEN9JHjCXfDMrE59LUMJWsTD82wTYk8A==",
       "license": "MIT",
       "dependencies": {
         "encoding-japanese": "2.2.0",
-        "iconv-lite": "0.7.2",
+        "iconv-lite": "0.7.3",
         "libbase64": "1.3.0",
         "libqp": "2.1.1"
       }
     },
     "node_modules/libmime/node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -3459,7 +3461,8 @@
     "node_modules/libqp": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
-      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow=="
+      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
+      "license": "MIT"
     },
     "node_modules/lie": {
       "version": "3.3.0",
@@ -3731,9 +3734,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",
@@ -3857,27 +3860,28 @@
       }
     },
     "node_modules/mailparser": {
-      "version": "3.9.11",
-      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.11.tgz",
-      "integrity": "sha512-N1LPZwp1yVblJQukv5NAedlkHeA+PmZYdPCfk0Uwohn8JFOM8fYoUGF978qwlQcd3AlUleuzK0fu/EFAHPM9tg==",
+      "version": "3.9.14",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.14.tgz",
+      "integrity": "sha512-3QD6TRXcyXtq2NCuyA2AEjqmallQkyxYmZI9GMCIvQDCaB9Uc034WUI1x8RUBYFnk5+p7h14JEz4O/lrxQmttw==",
       "license": "MIT",
       "dependencies": {
-        "@zone-eu/mailsplit": "5.4.12",
+        "@zone-eu/mailsplit": "5.4.14",
         "encoding-japanese": "2.2.0",
         "he": "1.2.0",
         "html-to-text": "10.0.0",
-        "iconv-lite": "0.7.2",
-        "libmime": "5.3.8",
-        "linkify-it": "5.0.1",
-        "nodemailer": "9.0.1",
+        "iconv-lite": "0.7.3",
+        "libmime": "5.4.1",
+        "linkify-it": "5.0.2",
+        "nodemailer": "9.0.3",
         "punycode.js": "2.3.1",
         "tlds": "1.261.0"
       }
     },
     "node_modules/mailparser/node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -3935,9 +3939,9 @@
       "license": "MIT"
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3999,9 +4003,9 @@
       "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw=="
     },
     "node_modules/nodemailer": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
-      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -4302,9 +4306,9 @@
       "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4590,9 +4594,10 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.14"
       }

--- a/package.json
+++ b/package.json
@@ -48,13 +48,15 @@
     "@aws-sdk/client-ssm": "^3.1070.0",
     "@types/aws-lambda": "^8.10.161",
     "@types/pdf-parse": "^1.1.5",
+    "adm-zip": "^0.5.17",
     "exceljs": "^4.4.0",
-    "mailparser": "^3.9.10",
+    "mailparser": "^3.9.11",
     "pdf-parse": "^1.1.1"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^20.4.4",
     "@eslint/js": "^10.0.1",
+    "@types/adm-zip": "^0.5.8",
     "@types/mailparser": "^3.4.6",
     "@types/node": "^25.9.2",
     "@typescript-eslint/eslint-plugin": "^8.61.1",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     "@aws-sdk/client-ssm": "^3.1070.0",
     "@types/aws-lambda": "^8.10.161",
     "@types/pdf-parse": "^1.1.5",
-    "adm-zip": "^0.5.17",
+    "adm-zip": "^0.6.0",
     "exceljs": "^4.4.0",
-    "mailparser": "^3.9.11",
+    "mailparser": "^3.9.14",
     "pdf-parse": "^1.1.1"
   },
   "devDependencies": {

--- a/src/choice/choice-hotel-stats-parser.test.ts
+++ b/src/choice/choice-hotel-stats-parser.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseHotelStats,
+  getRevParValue,
+  REVPAR_HEADER_PREFIX,
+} from "./choice-hotel-stats-parser";
+
+// ─── Fixture ──────────────────────────────────────────────────────────────────
+
+// Condensed two-column fixture (enough columns to exercise all logic)
+const FIXTURE_HEADER =
+  "Business Date: 6/14/2026," +
+  "Room Statistics_Total Rooms," +
+  "Room Statistics_Out Of Order," +
+  "Total Occupied Rooms," +
+  "Comp Rooms," +
+  "Occupancy Statistics_Occ% of Total Rooms," +
+  "Occupancy Statistics_ADR for Total Occupied Rooms," +
+  `${REVPAR_HEADER_PREFIX}6/14/2026`;
+
+const FIXTURE_DATA = ",61,0,37,0,60.66%,202.52,122.84";
+
+const FIXTURE = `${FIXTURE_HEADER}\n${FIXTURE_DATA}`;
+
+// ─── parseHotelStats ─────────────────────────────────────────────────────────
+
+describe("parseHotelStats", () => {
+  it("extracts business date from first column header", () => {
+    const result = parseHotelStats(FIXTURE);
+    expect(result.businessDate).toBe("2026-06-14");
+  });
+
+  it("zero-pads single-digit months and days", () => {
+    const header = "Business Date: 6/5/2026,Col2";
+    const data = ",val2";
+    const result = parseHotelStats(`${header}\n${data}`);
+    expect(result.businessDate).toBe("2026-06-05");
+  });
+
+  it("stores all column values keyed by header name", () => {
+    const result = parseHotelStats(FIXTURE);
+    expect(result.columns.get("Room Statistics_Total Rooms")).toBe("61");
+    expect(result.columns.get("Room Statistics_Out Of Order")).toBe("0");
+    expect(result.columns.get("Total Occupied Rooms")).toBe("37");
+    expect(result.columns.get("Comp Rooms")).toBe("0");
+    expect(result.columns.get("Occupancy Statistics_Occ% of Total Rooms")).toBe(
+      "60.66%",
+    );
+    expect(
+      result.columns.get("Occupancy Statistics_ADR for Total Occupied Rooms"),
+    ).toBe("202.52");
+  });
+
+  it("stores the full RevPAR header including date", () => {
+    const result = parseHotelStats(FIXTURE);
+    const revparKey = `${REVPAR_HEADER_PREFIX}6/14/2026`;
+    expect(result.columns.has(revparKey)).toBe(true);
+    expect(result.columns.get(revparKey)).toBe("122.84");
+  });
+
+  it("throws when fewer than two lines provided", () => {
+    expect(() => parseHotelStats("")).toThrow();
+    expect(() => parseHotelStats("OnlyHeader")).toThrow();
+  });
+
+  it("throws when first header does not contain 'Business Date:'", () => {
+    const bad = "Not a date,Col2\n,val2";
+    expect(() => parseHotelStats(bad)).toThrow(/business date/i);
+  });
+
+  it("handles Windows CRLF line endings", () => {
+    const crlfFixture = FIXTURE.replace(/\n/g, "\r\n");
+    const result = parseHotelStats(crlfFixture);
+    expect(result.businessDate).toBe("2026-06-14");
+    expect(result.columns.get("Room Statistics_Total Rooms")).toBe("61");
+  });
+});
+
+// ─── getRevParValue ───────────────────────────────────────────────────────────
+
+describe("getRevParValue", () => {
+  it("returns the RevPAR value via prefix matching", () => {
+    const result = parseHotelStats(FIXTURE);
+    expect(getRevParValue(result)).toBe("122.84");
+  });
+
+  it("returns undefined when RevPAR column is absent", () => {
+    const noRevPar = "Business Date: 1/1/2026,Other\n,val";
+    const result = parseHotelStats(noRevPar);
+    expect(getRevParValue(result)).toBeUndefined();
+  });
+});

--- a/src/choice/choice-hotel-stats-parser.ts
+++ b/src/choice/choice-hotel-stats-parser.ts
@@ -1,0 +1,102 @@
+/**
+ * @fileoverview Choice Hotels Hotel Statistics Parser
+ *
+ * Parses the `Hotel Statistics_YYYY-MM-DD.csv` file exported nightly by the
+ * Choice Hotels night-audit system.
+ *
+ * File structure (comma-separated, all fields quoted):
+ *   Row 1 — Header row: each column name describes a metric.
+ *            The first column is always "Business Date: M/D/YYYY".
+ *   Row 2 — Data row: a single row of values corresponding to the headers.
+ *
+ * The RevPAR column header embeds the business date and changes each night:
+ *   e.g. "Occupancy Statistics_RevPar_6/23/2026"
+ * Callers should use the exported REVPAR_HEADER_PREFIX to detect this column.
+ */
+
+import { parseCsvRow } from "./choice-journal-summary-parser";
+
+/** Pattern prefix for the RevPAR column header (date is appended nightly) */
+export const REVPAR_HEADER_PREFIX = "Occupancy Statistics_RevPar_";
+
+/** Parsed Hotel Statistics file */
+export interface HotelStatsData {
+  /**
+   * Business date extracted from the first column header.
+   * Format: YYYY-MM-DD.
+   */
+  businessDate: string;
+  /**
+   * All column values keyed by their header name.
+   * The RevPAR key is normalised — the actual header is stored as-is,
+   * so callers can use `getRevParValue()` for lookup.
+   */
+  columns: Map<string, string>;
+}
+
+/**
+ * Parse the raw text content of a `Hotel Statistics_*.csv` file.
+ *
+ * @param rawContent - UTF-8 text content of the file
+ * @returns Parsed hotel statistics data
+ * @throws Error if the header or data row is missing
+ */
+export function parseHotelStats(rawContent: string): HotelStatsData {
+  const lines = rawContent
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  if (lines.length < 2) {
+    throw new Error(
+      "Hotel Statistics file must have a header row and a data row",
+    );
+  }
+
+  const headers = parseCsvRow(lines[0]).map((h) => h.trim());
+  const values = parseCsvRow(lines[1]).map((v) => v.trim());
+
+  // First column header: "Business Date: 6/23/2026"
+  const businessDate = parseBusinessDate(headers[0]);
+
+  const columns = new Map<string, string>();
+  for (let i = 0; i < headers.length; i++) {
+    columns.set(headers[i], values[i] ?? "");
+  }
+
+  return { businessDate, columns };
+}
+
+/**
+ * Look up the RevPAR value from a stats data map.
+ * The RevPAR column header changes each day (it includes the business date),
+ * so we scan for the key that starts with `REVPAR_HEADER_PREFIX`.
+ *
+ * @returns The string value or `undefined` if the column is not present
+ */
+export function getRevParValue(data: HotelStatsData): string | undefined {
+  for (const [key, val] of data.columns.entries()) {
+    if (key.startsWith(REVPAR_HEADER_PREFIX)) {
+      return val;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Parse the business date from the first column header.
+ * Input:  "Business Date: 6/23/2026"
+ * Output: "2026-06-23"
+ *
+ * @throws Error if the date cannot be extracted
+ */
+function parseBusinessDate(header: string): string {
+  const match = header.match(/Business Date:\s*(\d{1,2})\/(\d{1,2})\/(\d{4})/);
+  if (!match) {
+    throw new Error(
+      `Cannot parse business date from Hotel Statistics header: "${header}"`,
+    );
+  }
+  const [, month, day, year] = match;
+  return `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
+}

--- a/src/choice/choice-journal-summary-parser.test.ts
+++ b/src/choice/choice-journal-summary-parser.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseJournalSummary,
+  parseAmount,
+  parseCsvRow,
+} from "./choice-journal-summary-parser";
+
+// ─── parseCsvRow ──────────────────────────────────────────────────────────────
+
+describe("parseCsvRow", () => {
+  it("parses simple unquoted fields", () => {
+    expect(parseCsvRow("AX,0,0,0")).toEqual(["AX", "0", "0", "0"]);
+  });
+
+  it("parses quoted fields containing commas", () => {
+    expect(parseCsvRow('AX,"-3,789.05",0,0')).toEqual([
+      "AX",
+      "-3,789.05",
+      "0",
+      "0",
+    ]);
+  });
+
+  it("parses escaped double-quotes inside quoted field", () => {
+    expect(parseCsvRow('"say ""hello""",next')).toEqual([
+      'say "hello"',
+      "next",
+    ]);
+  });
+
+  it("handles empty fields", () => {
+    expect(parseCsvRow("a,,c")).toEqual(["a", "", "c"]);
+  });
+
+  it("parses fully-quoted row like Choice Hotels header", () => {
+    expect(
+      parseCsvRow(
+        '"Transaction Code","Postings","Corrections","Adjustments","Totals"',
+      ),
+    ).toEqual([
+      "Transaction Code",
+      "Postings",
+      "Corrections",
+      "Adjustments",
+      "Totals",
+    ]);
+  });
+});
+
+// ─── parseAmount ─────────────────────────────────────────────────────────────
+
+describe("parseAmount", () => {
+  it("parses plain positive amount", () => {
+    expect(parseAmount("8355.40")).toBeCloseTo(8355.4);
+  });
+
+  it("parses amount with comma separators", () => {
+    expect(parseAmount("8,355.40")).toBeCloseTo(8355.4);
+  });
+
+  it("parses plain negative amount", () => {
+    expect(parseAmount("-3,789.05")).toBeCloseTo(-3789.05);
+  });
+
+  it("parses parenthesised negative amount", () => {
+    expect(parseAmount("(1,172.25)")).toBeCloseTo(-1172.25);
+  });
+
+  it("parses zero", () => {
+    expect(parseAmount("0")).toBe(0);
+  });
+
+  it("parses empty string as zero", () => {
+    expect(parseAmount("")).toBe(0);
+  });
+
+  it("parses simple negative without commas", () => {
+    expect(parseAmount("-162.98")).toBeCloseTo(-162.98);
+  });
+});
+
+// ─── parseJournalSummary ─────────────────────────────────────────────────────
+
+describe("parseJournalSummary", () => {
+  // Minimal fixture built from the Choice MT118 sample (6/14/2026)
+  const FIXTURE = [
+    "Transaction Code,Postings,Corrections,Adjustments,Totals,Guest Ledger,AR Ledger,AdvDep Ledger,Transactions,Post,Corr,Adj",
+    'AX,"-3,789.05",0,0,"-3,789.05","-3,789.05",0,0,11,11,0,0',
+    "CA,-162.98,0,0,-162.98,-162.98,0,0,1,1,0,0",
+    'MC,"-4,070.87",0,221.45,"-3,849.42","-3,987.86",0,138.44,14,13,0,1',
+    "NS,0,0,-862.16,-862.16,-862.16,0,0,4,0,0,4",
+    "PET,100,0,-25,75,75,0,0,5,4,0,1",
+    'RM,"8,666.27",0,-310.87,"8,355.40","8,355.40",0,0,56,53,0,3',
+    "T1,576.79,0,-24.87,551.92,551.92,0,0,46,43,0,3",
+    "T5,212,0,-4,208,208,0,0,54,53,0,1",
+    'VI,"-15,331.48",0,694.71,"-14,636.77","-14,814.67",0,177.9,39,34,0,5',
+    "*Revenues do not include taxes,,,,,,,,,,,",
+    ",,,,,,,,,,,",
+  ].join("\n");
+
+  it("parses all transaction codes", () => {
+    const result = parseJournalSummary(FIXTURE);
+    expect(result.transactions).toHaveLength(9);
+    const codes = result.transactions.map((t) => t.transactionCode);
+    expect(codes).toEqual([
+      "AX",
+      "CA",
+      "MC",
+      "NS",
+      "PET",
+      "RM",
+      "T1",
+      "T5",
+      "VI",
+    ]);
+  });
+
+  it("correctly reads Totals column", () => {
+    const result = parseJournalSummary(FIXTURE);
+    const ax = result.transactions.find((t) => t.transactionCode === "AX")!;
+    expect(ax.totals).toBeCloseTo(-3789.05);
+    const rm = result.transactions.find((t) => t.transactionCode === "RM")!;
+    expect(rm.totals).toBeCloseTo(8355.4);
+  });
+
+  it("skips footer row starting with *", () => {
+    const result = parseJournalSummary(FIXTURE);
+    const codes = result.transactions.map((t) => t.transactionCode);
+    expect(codes).not.toContain("*Revenues do not include taxes");
+  });
+
+  it("skips blank-code rows", () => {
+    const result = parseJournalSummary(FIXTURE);
+    expect(result.transactions.every((t) => t.transactionCode !== "")).toBe(
+      true,
+    );
+  });
+
+  it("sums Guest Ledger column correctly", () => {
+    const result = parseJournalSummary(FIXTURE);
+    // AX:-3789.05 + CA:-162.98 + MC:-3987.86 + NS:-862.16 + PET:75 +
+    // RM:8355.40 + T1:551.92 + T5:208 + VI:-14814.67 = -14426.40
+    expect(result.guestLedgerSum).toBeCloseTo(-14426.4);
+  });
+
+  it("sums AR Ledger column as zero (all zeros in fixture)", () => {
+    const result = parseJournalSummary(FIXTURE);
+    expect(result.arLedgerSum).toBe(0);
+  });
+
+  it("sums AdvDep Ledger column correctly", () => {
+    const result = parseJournalSummary(FIXTURE);
+    // MC:138.44 + VI:177.9 = 316.34
+    expect(result.advDepLedgerSum).toBeCloseTo(316.34);
+  });
+
+  it("throws on file with no data rows", () => {
+    expect(() => parseJournalSummary("")).toThrow();
+    expect(() => parseJournalSummary("Header only row")).toThrow();
+  });
+
+  it("throws when required headers are missing", () => {
+    const bad = "CodeOnly,SomeOther\nAX,100";
+    expect(() => parseJournalSummary(bad)).toThrow(
+      /Transaction Code, Totals, Guest Ledger/,
+    );
+  });
+
+  it("handles Windows CRLF line endings", () => {
+    const crlfFixture = FIXTURE.replace(/\n/g, "\r\n");
+    const result = parseJournalSummary(crlfFixture);
+    expect(result.transactions).toHaveLength(9);
+  });
+});

--- a/src/choice/choice-journal-summary-parser.ts
+++ b/src/choice/choice-journal-summary-parser.ts
@@ -1,0 +1,166 @@
+/**
+ * @fileoverview Choice Hotels Journal Summary Parser
+ *
+ * Parses the `Hotel Journal Summary_YYYY-MM-DD.csv` file exported nightly by
+ * the Choice Hotels night-audit system.
+ *
+ * File structure (comma-separated, all fields quoted):
+ *   Row 1 — Header: Transaction Code, Postings, Corrections, Adjustments,
+ *            Totals, Guest Ledger, AR Ledger, AdvDep Ledger, Transactions,
+ *            Post, Corr, Adj
+ *   Rows 2..N — One data row per transaction code
+ *   Last row  — Footer "*Revenues do not include taxes" (skipped)
+ *
+ * Negative amounts appear in two formats depending on property:
+ *   - Plain negative:       -3,789.05
+ *   - Parentheses negative: (3,789.05)
+ *
+ * Most JE accounts use the value from the "Totals" column.
+ * Three special ledger accounts use the *column-sum* across all data rows:
+ *   - Guest Ledger  → 10006-654
+ *   - AR Ledger     → 10502-2051
+ *   - AdvDep Ledger → 24000-263
+ */
+
+/** A single transaction code row from the Journal Summary */
+export interface JournalSummaryTransaction {
+  /** Choice transaction code (e.g. "RM", "AX", "T1") */
+  transactionCode: string;
+  /** Net amount from the Totals column */
+  totals: number;
+  /** Amount in the Guest Ledger column (may differ from Totals for split payments) */
+  guestLedger: number;
+  /** Amount in the AR Ledger column */
+  arLedger: number;
+  /** Amount in the AdvDep Ledger column */
+  advDepLedger: number;
+}
+
+/** Parsed Journal Summary file */
+export interface JournalSummaryData {
+  /** All data rows (footer excluded) */
+  transactions: JournalSummaryTransaction[];
+  /** Sum of the Guest Ledger column across all rows */
+  guestLedgerSum: number;
+  /** Sum of the AR Ledger column across all rows */
+  arLedgerSum: number;
+  /** Sum of the AdvDep Ledger column across all rows */
+  advDepLedgerSum: number;
+}
+
+/**
+ * Parse the raw text content of a `Hotel Journal Summary_*.csv` file.
+ *
+ * @param rawContent - UTF-8 text content of the file
+ * @returns Parsed journal summary data
+ * @throws Error if the header row is missing required columns
+ */
+export function parseJournalSummary(rawContent: string): JournalSummaryData {
+  const lines = rawContent
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  if (lines.length < 2) {
+    throw new Error("Journal Summary file has no data rows");
+  }
+
+  const headerCols = parseCsvRow(lines[0]).map((h) => h.trim());
+
+  const idxCode = headerCols.indexOf("Transaction Code");
+  const idxTotals = headerCols.indexOf("Totals");
+  const idxGuest = headerCols.indexOf("Guest Ledger");
+  const idxAR = headerCols.indexOf("AR Ledger");
+  const idxAdvDep = headerCols.indexOf("AdvDep Ledger");
+
+  if (idxCode === -1 || idxTotals === -1 || idxGuest === -1) {
+    throw new Error(
+      "Journal Summary header is missing required columns " +
+        "(Transaction Code, Totals, Guest Ledger)",
+    );
+  }
+
+  const transactions: JournalSummaryTransaction[] = [];
+  let guestLedgerSum = 0;
+  let arLedgerSum = 0;
+  let advDepLedgerSum = 0;
+
+  for (let i = 1; i < lines.length; i++) {
+    const cols = parseCsvRow(lines[i]);
+    const code = (cols[idxCode] ?? "").trim();
+
+    // Skip footer row and any blank codes
+    if (!code || code.startsWith("*")) continue;
+
+    const totals = parseAmount(cols[idxTotals] ?? "0");
+    const guestLedger = parseAmount(cols[idxGuest] ?? "0");
+    const arLedger = idxAR !== -1 ? parseAmount(cols[idxAR] ?? "0") : 0;
+    const advDepLedger =
+      idxAdvDep !== -1 ? parseAmount(cols[idxAdvDep] ?? "0") : 0;
+
+    transactions.push({
+      transactionCode: code,
+      totals,
+      guestLedger,
+      arLedger,
+      advDepLedger,
+    });
+
+    guestLedgerSum += guestLedger;
+    arLedgerSum += arLedger;
+    advDepLedgerSum += advDepLedger;
+  }
+
+  return { transactions, guestLedgerSum, arLedgerSum, advDepLedgerSum };
+}
+
+/**
+ * Parse a numeric amount that may be formatted as:
+ *   - Plain negative:       -3,789.05  or  -162.98
+ *   - Parentheses negative: (3,789.05) or  (162.98)
+ *   - Plain positive:        8,355.40  or   100
+ * Commas are stripped before parsing.
+ */
+export function parseAmount(raw: string): number {
+  const trimmed = raw.trim();
+  if (!trimmed) return 0;
+
+  // Parenthesised negative: (1,234.56) → -1234.56
+  const parenMatch = trimmed.match(/^\(([0-9,]+(?:\.[0-9]+)?)\)$/);
+  if (parenMatch) {
+    return -parseFloat(parenMatch[1].replace(/,/g, ""));
+  }
+
+  return parseFloat(trimmed.replace(/,/g, "")) || 0;
+}
+
+/**
+ * Minimal CSV row parser that handles double-quoted fields containing
+ * commas and escaped quotes.  Choice Hotels files quote all fields.
+ */
+export function parseCsvRow(line: string): string[] {
+  const result: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        // Escaped quote inside a quoted field
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === "," && !inQuotes) {
+      result.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  result.push(current);
+  return result;
+}

--- a/src/choice/choice-mapping-loader.test.ts
+++ b/src/choice/choice-mapping-loader.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import {
+  loadChoiceMapping,
+  parseChoiceMappingWorkbook,
+  findChoiceMappingEntry,
+  CHOICE_NOT_MAPPED,
+  CHOICE_MAPPING_PREFIX,
+  CHOICE_SHEET_NAME,
+} from "./choice-mapping-loader";
+import ExcelJS from "exceljs";
+
+// ---- Mocks for loadChoiceMapping ----
+
+vi.mock("@aws-sdk/client-s3");
+vi.mock("../utils/retry");
+vi.mock("../utils/logger", () => ({
+  createCorrelatedLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { retryS3Operation } from "../utils/retry";
+const mockRetryS3 = retryS3Operation as Mock;
+
+// S3Client is passed in from outside; retryS3Operation is fully mocked so
+// s3Client.send is never actually invoked in these tests.
+const stubS3Client = {} as Parameters<typeof loadChoiceMapping>[0];
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal in-memory XLSX buffer with a "Choice" sheet.
+ * Columns: [Src Data Code, Src Desc, Multiplier, Property Name, Glacct Code, Glacct Name, Acct Type]
+ */
+async function buildTestXlsx(
+  rows: Array<(string | number | null)[]>,
+): Promise<Buffer> {
+  const workbook = new ExcelJS.Workbook();
+  const ws = workbook.addWorksheet(CHOICE_SHEET_NAME);
+
+  ws.addRow([
+    "Src Data Code",
+    "Src Desc",
+    "Multiplier",
+    "Property Name",
+    "Glacct Code",
+    "Glacct Name",
+    "Acct Type",
+  ]);
+  for (const row of rows) {
+    ws.addRow(row);
+  }
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  return Buffer.from(buffer);
+}
+
+// ─── parseChoiceMappingWorkbook ──────────────────────────────────────────────
+
+describe("parseChoiceMappingWorkbook", () => {
+  it("parses a global (no property) accounting entry", async () => {
+    const buf = await buildTestXlsx([
+      ["RM", "ROOM CHARGE", 1, null, "40110-634", "Room Revenue", "Accounting"],
+    ]);
+    const mapping = await parseChoiceMappingWorkbook(buf);
+
+    expect(mapping.has("RM")).toBe(true);
+    const [entry] = mapping.get("RM")!;
+    expect(entry.srcDataCode).toBe("RM");
+    expect(entry.srcDesc).toBe("ROOM CHARGE");
+    expect(entry.multiplier).toBe(1);
+    expect(entry.propertyName).toBe("");
+    expect(entry.glAcctCode).toBe("40110-634");
+    expect(entry.glAcctName).toBe("Room Revenue");
+    expect(entry.acctType).toBe("Accounting");
+  });
+
+  it("parses a property-specific entry", async () => {
+    const buf = await buildTestXlsx([
+      [
+        "AX",
+        "AMERICAN EXPRESS",
+        -1,
+        "Comfort Inn - Missoula",
+        "10190-718",
+        "Cash in Bank",
+        "Accounting",
+      ],
+    ]);
+    const mapping = await parseChoiceMappingWorkbook(buf);
+    const [entry] = mapping.get("AX")!;
+    expect(entry.propertyName).toBe("Comfort Inn - Missoula");
+    expect(entry.multiplier).toBe(-1);
+  });
+
+  it("groups multiple rows for the same Src Data Code", async () => {
+    const buf = await buildTestXlsx([
+      [
+        "AX",
+        "AMEX",
+        -1,
+        "Comfort Inn - Missoula",
+        "10190-718",
+        "Cash",
+        "Accounting",
+      ],
+      [
+        "AX",
+        "AMEX",
+        -1,
+        "Comfort Inn & Suites - Ashland",
+        "10090-701",
+        "Cash",
+        "Accounting",
+      ],
+    ]);
+    const mapping = await parseChoiceMappingWorkbook(buf);
+    expect(mapping.get("AX")).toHaveLength(2);
+  });
+
+  it("parses a Statistical entry", async () => {
+    const buf = await buildTestXlsx([
+      [
+        "Occupancy Statistics_ADR for Total Occupied Rooms",
+        "ADR",
+        1,
+        null,
+        "90001-418",
+        "ADR",
+        "Statistical",
+      ],
+    ]);
+    const mapping = await parseChoiceMappingWorkbook(buf);
+    const [entry] = mapping.get(
+      "Occupancy Statistics_ADR for Total Occupied Rooms",
+    )!;
+    expect(entry.acctType).toBe("Statistical");
+    expect(entry.glAcctCode).toBe("90001-418");
+  });
+
+  it("defaults missing glAcctCode to CHOICE_NOT_MAPPED", async () => {
+    const buf = await buildTestXlsx([
+      ["XX", "Unknown", 1, null, "", "Name", "Accounting"],
+    ]);
+    const mapping = await parseChoiceMappingWorkbook(buf);
+    expect(mapping.get("XX")![0].glAcctCode).toBe(CHOICE_NOT_MAPPED);
+  });
+
+  it("skips rows with no Src Data Code", async () => {
+    const buf = await buildTestXlsx([
+      ["", "Empty", 1, null, "10000-1", "Acct", "Accounting"],
+      ["RM", "Room", 1, null, "40110-634", "Revenue", "Accounting"],
+    ]);
+    const mapping = await parseChoiceMappingWorkbook(buf);
+    expect(mapping.size).toBe(1);
+    expect(mapping.has("RM")).toBe(true);
+  });
+
+  it("throws when the Choice sheet is absent", async () => {
+    const workbook = new ExcelJS.Workbook();
+    workbook.addWorksheet("WrongSheet");
+    const buffer = Buffer.from(await workbook.xlsx.writeBuffer());
+    await expect(parseChoiceMappingWorkbook(buffer)).rejects.toThrow(
+      /Sheet "Choice" not found/,
+    );
+  });
+});
+
+// ─── findChoiceMappingEntry ───────────────────────────────────────────────────
+
+describe("findChoiceMappingEntry", () => {
+  it("returns property-specific entry when name matches", async () => {
+    const buf = await buildTestXlsx([
+      [
+        "AX",
+        "AMEX",
+        -1,
+        "Comfort Inn - Missoula",
+        "10190-718",
+        "CashMis",
+        "Accounting",
+      ],
+      [
+        "AX",
+        "AMEX",
+        -1,
+        "Comfort Inn & Suites - Ashland",
+        "10090-701",
+        "CashAsh",
+        "Accounting",
+      ],
+    ]);
+    const mapping = await parseChoiceMappingWorkbook(buf);
+    const entry = findChoiceMappingEntry(
+      mapping,
+      "AX",
+      "Comfort Inn - Missoula",
+    );
+    expect(entry?.glAcctCode).toBe("10190-718");
+  });
+
+  it("falls back to global entry when property name does not match", async () => {
+    const buf = await buildTestXlsx([
+      ["RM", "Room Charge", 1, null, "40110-634", "Room Rev", "Accounting"],
+    ]);
+    const mapping = await parseChoiceMappingWorkbook(buf);
+    const entry = findChoiceMappingEntry(mapping, "RM", "Any Property");
+    expect(entry?.glAcctCode).toBe("40110-634");
+  });
+
+  it("returns undefined when code is not in mapping", async () => {
+    const buf = await buildTestXlsx([
+      ["RM", "Room Charge", 1, null, "40110-634", "Room Rev", "Accounting"],
+    ]);
+    const mapping = await parseChoiceMappingWorkbook(buf);
+    expect(findChoiceMappingEntry(mapping, "MISSING", "Any")).toBeUndefined();
+  });
+
+  it("returns undefined when all entries have non-matching property names", async () => {
+    const buf = await buildTestXlsx([
+      [
+        "LB",
+        "Lounge",
+        1,
+        "Comfort Inn & Suites - Ashland",
+        "40121-724",
+        "Alcohol",
+        "Accounting",
+      ],
+    ]);
+    const mapping = await parseChoiceMappingWorkbook(buf);
+    // Missoula doesn't have an LB entry and there's no global fallback
+    expect(
+      findChoiceMappingEntry(mapping, "LB", "Comfort Inn - Missoula"),
+    ).toBeUndefined();
+  });
+});
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+describe("Choice mapping constants", () => {
+  it("has the expected S3 prefix", () => {
+    expect(CHOICE_MAPPING_PREFIX).toBe("choice/");
+  });
+
+  it("has the expected sheet name", () => {
+    expect(CHOICE_SHEET_NAME).toBe("Choice");
+  });
+});
+
+// ─── loadChoiceMapping ────────────────────────────────────────────────────────
+
+describe("loadChoiceMapping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when the choice/ prefix has no XLSX files", async () => {
+    mockRetryS3.mockResolvedValueOnce({ Contents: [] });
+
+    const result = await loadChoiceMapping(stubS3Client, "test-bucket", "cid");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when Contents is undefined", async () => {
+    mockRetryS3.mockResolvedValueOnce({});
+
+    const result = await loadChoiceMapping(stubS3Client, "test-bucket", "cid");
+    expect(result).toBeNull();
+  });
+
+  it("ignores non-XLSX files and returns null when none remain", async () => {
+    mockRetryS3.mockResolvedValueOnce({
+      Contents: [
+        { Key: `${CHOICE_MAPPING_PREFIX}readme.txt`, LastModified: new Date() },
+      ],
+    });
+
+    const result = await loadChoiceMapping(stubS3Client, "test-bucket", "cid");
+    expect(result).toBeNull();
+  });
+
+  it("fetches the most-recently-modified XLSX and returns a mapping", async () => {
+    const buf = await buildTestXlsx([
+      ["RM", "ROOM CHARGE", 1, null, "40110-634", "Room Revenue", "Accounting"],
+    ]);
+
+    mockRetryS3
+      .mockResolvedValueOnce({
+        Contents: [
+          {
+            Key: `${CHOICE_MAPPING_PREFIX}choice-mapping.xlsx`,
+            LastModified: new Date("2026-06-01"),
+            Size: buf.length,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        Body: {
+          transformToByteArray: () => Promise.resolve(new Uint8Array(buf)),
+        },
+      });
+
+    const mapping = await loadChoiceMapping(stubS3Client, "test-bucket", "cid");
+    expect(mapping).not.toBeNull();
+    expect(mapping!.has("RM")).toBe(true);
+  });
+
+  it("picks the newest file when multiple XLSX files exist", async () => {
+    const bufNew = await buildTestXlsx([
+      ["NEW", "new entry", 1, null, "99999-999", "New", "Accounting"],
+    ]);
+
+    mockRetryS3
+      .mockResolvedValueOnce({
+        Contents: [
+          {
+            Key: `${CHOICE_MAPPING_PREFIX}old.xlsx`,
+            LastModified: new Date("2026-01-01"),
+          },
+          {
+            Key: `${CHOICE_MAPPING_PREFIX}new.xlsx`,
+            LastModified: new Date("2026-06-01"),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        Body: {
+          transformToByteArray: () => Promise.resolve(new Uint8Array(bufNew)),
+        },
+      });
+
+    const mapping = await loadChoiceMapping(stubS3Client, "test-bucket", "cid");
+    expect(mapping!.has("NEW")).toBe(true);
+    expect(mapping!.has("OLD")).toBe(false);
+  });
+
+  it("returns null when response body is missing", async () => {
+    mockRetryS3
+      .mockResolvedValueOnce({
+        Contents: [
+          {
+            Key: `${CHOICE_MAPPING_PREFIX}mapping.xlsx`,
+            LastModified: new Date(),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ Body: null });
+
+    const result = await loadChoiceMapping(stubS3Client, "test-bucket", "cid");
+    expect(result).toBeNull();
+  });
+
+  it("returns null and logs when retryS3Operation throws", async () => {
+    mockRetryS3.mockRejectedValueOnce(new Error("S3 unavailable"));
+
+    const result = await loadChoiceMapping(stubS3Client, "test-bucket", "cid");
+    expect(result).toBeNull();
+  });
+});

--- a/src/choice/choice-mapping-loader.ts
+++ b/src/choice/choice-mapping-loader.ts
@@ -1,0 +1,247 @@
+/**
+ * @fileoverview Choice Hotels Mapping Loader
+ *
+ * Loads and parses the Choice Hotels → NetSuite GL mapping workbook from S3.
+ * The mapping XLSX must be uploaded under the `choice/` prefix in the
+ * mapping-files bucket so it does not conflict with other pipeline mappings.
+ *
+ * Sheet: "Choice"
+ * Key columns:
+ *   [1] Src Data Code  [2] Src Desc  [3] Multiplier  [4] Property Name
+ *   [5] Glacct Code    [6] Glacct Name  [7] Acct Type
+ *
+ * Property Name is empty / null for global entries that apply to all properties.
+ * Property-specific entries (e.g. cash-in-bank accounts) have the display name
+ * of the property as it was registered in the workbook.
+ *
+ * Acct Type values: "Accounting" (JE) or "Statistical" (StatJE).
+ */
+
+import ExcelJS from "exceljs";
+import { Readable } from "stream";
+import {
+  S3Client,
+  ListObjectsV2Command,
+  GetObjectCommand,
+} from "@aws-sdk/client-s3";
+import { createCorrelatedLogger } from "../utils/logger";
+import { retryS3Operation } from "../utils/retry";
+
+export const CHOICE_MAPPING_PREFIX = "choice/";
+export const CHOICE_SHEET_NAME = "Choice";
+
+/** Glacct Code value indicating the source code has no NetSuite mapping */
+export const CHOICE_NOT_MAPPED = "Not Mapped";
+
+/** Placeholder suffix in the RevPAR mapping key; replaced with the actual date */
+export const REVPAR_DATE_PLACEHOLDER = "(Date)";
+
+/**
+ * A single row from the Choice mapping workbook.
+ */
+export interface ChoiceMappingEntry {
+  /** Choice Hotels transaction code or Hotel-Statistics column header */
+  srcDataCode: string;
+  /** Human-readable description of the source */
+  srcDesc: string;
+  /** Amount multiplier (1 or -1). Credit card / payment codes use -1. */
+  multiplier: number;
+  /**
+   * Display name of the property this entry applies to, e.g.
+   * "Comfort Inn - Missoula".  Empty string means the entry is global
+   * (applies to all Choice properties).
+   */
+  propertyName: string;
+  /**
+   * Full NetSuite GL account string: "<account>-<internalId>"
+   * (e.g. "40110-634").  Value is CHOICE_NOT_MAPPED when unmapped.
+   */
+  glAcctCode: string;
+  /** Human-readable account name */
+  glAcctName: string;
+  /** "Accounting" → JE, "Statistical" → StatJE */
+  acctType: "Accounting" | "Statistical";
+}
+
+/**
+ * Keyed by Src Data Code for O(1) lookup.
+ * Each key maps to an array because a code may appear multiple times with
+ * different property-name values (e.g. cash-in-bank entries per property).
+ */
+export type ChoiceMapping = Map<string, ChoiceMappingEntry[]>;
+
+/**
+ * Download and parse the most-recent Choice mapping XLSX from S3.
+ *
+ * @param s3Client - Authenticated S3 client
+ * @param mappingBucket - Name of the mapping-files S3 bucket
+ * @param correlationId - Correlation ID for logging
+ * @returns Parsed Choice mapping, or null if no file found / parsing fails
+ */
+export async function loadChoiceMapping(
+  s3Client: S3Client,
+  mappingBucket: string,
+  correlationId: string,
+): Promise<ChoiceMapping | null> {
+  const logger = createCorrelatedLogger(correlationId, {
+    operation: "load_choice_mapping",
+  });
+
+  try {
+    const listResult = await retryS3Operation(
+      () =>
+        s3Client.send(
+          new ListObjectsV2Command({
+            Bucket: mappingBucket,
+            Prefix: CHOICE_MAPPING_PREFIX,
+          }),
+        ),
+      correlationId,
+      "list_choice_mapping_files",
+      { maxRetries: 3, baseDelay: 1000 },
+    );
+
+    const mappingFiles = (listResult.Contents || [])
+      .filter((obj) => obj.Key?.toLowerCase().endsWith(".xlsx"))
+      .sort(
+        (a, b) =>
+          (b.LastModified?.getTime() || 0) - (a.LastModified?.getTime() || 0),
+      );
+
+    if (mappingFiles.length === 0) {
+      logger.warn("No Choice mapping XLSX found in S3", {
+        bucket: mappingBucket,
+        prefix: CHOICE_MAPPING_PREFIX,
+      });
+      return null;
+    }
+
+    const mappingKey = mappingFiles[0].Key!;
+    logger.info("Loading Choice mapping file", {
+      key: mappingKey,
+      size: mappingFiles[0].Size,
+    });
+
+    const response = await retryS3Operation(
+      () =>
+        s3Client.send(
+          new GetObjectCommand({ Bucket: mappingBucket, Key: mappingKey }),
+        ),
+      correlationId,
+      "download_choice_mapping",
+      { maxRetries: 3, baseDelay: 1000 },
+    );
+
+    if (!response.Body) {
+      throw new Error(`No content for Choice mapping file: ${mappingKey}`);
+    }
+
+    const bytes = await response.Body.transformToByteArray();
+    const buffer = Buffer.from(bytes);
+
+    const mapping = await parseChoiceMappingWorkbook(buffer);
+
+    const totalEntries = Array.from(mapping.values()).reduce(
+      (sum, arr) => sum + arr.length,
+      0,
+    );
+    logger.info("Choice mapping loaded successfully", {
+      key: mappingKey,
+      uniqueKeys: mapping.size,
+      totalEntries,
+    });
+
+    return mapping;
+  } catch (error) {
+    logger.error("Failed to load Choice mapping", error as Error);
+    return null;
+  }
+}
+
+/**
+ * Parse a Choice mapping XLSX buffer into a ChoiceMapping map.
+ * Exposed separately so it can be called in tests without S3.
+ */
+export async function parseChoiceMappingWorkbook(
+  buffer: Buffer,
+): Promise<ChoiceMapping> {
+  const workbook = new ExcelJS.Workbook();
+  const stream = Readable.from(buffer);
+  await workbook.xlsx.read(stream);
+
+  const worksheet = workbook.getWorksheet(CHOICE_SHEET_NAME);
+  if (!worksheet) {
+    throw new Error(
+      `Sheet "${CHOICE_SHEET_NAME}" not found in Choice mapping workbook`,
+    );
+  }
+
+  const mapping: ChoiceMapping = new Map();
+
+  // Row 1 is the header; data starts at row 2.
+  // Column layout (1-based):
+  //   [1] Src Data Code  [2] Src Desc  [3] Multiplier  [4] Property Name
+  //   [5] Glacct Code    [6] Glacct Name  [7] Acct Type
+  worksheet.eachRow((row, rowNumber) => {
+    if (rowNumber === 1) return;
+
+    const srcDataCode = String(row.getCell(1).value ?? "").trim();
+    if (!srcDataCode) return;
+
+    const rawAcctType = String(row.getCell(7).value ?? "").trim();
+    const acctType: ChoiceMappingEntry["acctType"] =
+      rawAcctType === "Statistical" ? "Statistical" : "Accounting";
+
+    const glAcctCode = String(row.getCell(5).value ?? "").trim();
+    const rawPropertyName = row.getCell(4).value;
+    const propertyName =
+      rawPropertyName === null || rawPropertyName === undefined
+        ? ""
+        : String(rawPropertyName).trim();
+
+    const entry: ChoiceMappingEntry = {
+      srcDataCode,
+      srcDesc: String(row.getCell(2).value ?? "").trim(),
+      multiplier: Number(row.getCell(3).value ?? 1) || 1,
+      propertyName,
+      glAcctCode: glAcctCode || CHOICE_NOT_MAPPED,
+      glAcctName: String(row.getCell(6).value ?? "").trim(),
+      acctType,
+    };
+
+    const existing = mapping.get(srcDataCode);
+    if (existing) {
+      existing.push(entry);
+    } else {
+      mapping.set(srcDataCode, [entry]);
+    }
+  });
+
+  return mapping;
+}
+
+/**
+ * Find the best-matching mapping entry for a given source code and property.
+ *
+ * Priority:
+ *   1. Entry with a matching property name
+ *   2. Entry with an empty/global property name
+ *   3. undefined (no mapping)
+ *
+ * @param mapping - Full Choice mapping
+ * @param srcDataCode - Source transaction code or stat column header
+ * @param propertyName - Display name of the property (as in the workbook)
+ */
+export function findChoiceMappingEntry(
+  mapping: ChoiceMapping,
+  srcDataCode: string,
+  propertyName: string,
+): ChoiceMappingEntry | undefined {
+  const entries = mapping.get(srcDataCode);
+  if (!entries || entries.length === 0) return undefined;
+
+  return (
+    entries.find((e) => e.propertyName === propertyName) ??
+    entries.find((e) => !e.propertyName)
+  );
+}

--- a/src/choice/choice-transformation.test.ts
+++ b/src/choice/choice-transformation.test.ts
@@ -1,0 +1,494 @@
+import { describe, it, expect } from "vitest";
+import {
+  transformJournalSummaryToJERecords,
+  transformHotelStatsToStatJERecords,
+  parseStatAmount,
+  buildRevParHeader,
+} from "./choice-transformation";
+import { parseChoiceMappingWorkbook } from "./choice-mapping-loader";
+import { REVPAR_HEADER_PREFIX } from "./choice-hotel-stats-parser";
+import type { JournalSummaryData } from "./choice-journal-summary-parser";
+import type { HotelStatsData } from "./choice-hotel-stats-parser";
+import ExcelJS from "exceljs";
+
+// ─── Test Helpers ─────────────────────────────────────────────────────────────
+
+async function buildMapping(rows: Array<(string | number | null)[]>) {
+  const workbook = new ExcelJS.Workbook();
+  const ws = workbook.addWorksheet("Choice");
+  ws.addRow([
+    "Src Data Code",
+    "Src Desc",
+    "Multiplier",
+    "Property Name",
+    "Glacct Code",
+    "Glacct Name",
+    "Acct Type",
+  ]);
+  for (const row of rows) ws.addRow(row);
+  const buf = Buffer.from(await workbook.xlsx.writeBuffer());
+  return parseChoiceMappingWorkbook(buf);
+}
+
+// ─── parseStatAmount ─────────────────────────────────────────────────────────
+
+describe("parseStatAmount", () => {
+  it("strips percent sign", () => {
+    expect(parseStatAmount("60.66%")).toBeCloseTo(60.66);
+  });
+
+  it("parses plain decimal", () => {
+    expect(parseStatAmount("202.52")).toBeCloseTo(202.52);
+  });
+
+  it("parses integer", () => {
+    expect(parseStatAmount("37")).toBe(37);
+  });
+
+  it("returns 0 for empty string", () => {
+    expect(parseStatAmount("")).toBe(0);
+  });
+});
+
+// ─── buildRevParHeader ────────────────────────────────────────────────────────
+
+describe("buildRevParHeader", () => {
+  it("strips leading zeros from month and day", () => {
+    expect(buildRevParHeader("2026-06-14")).toBe(
+      `${REVPAR_HEADER_PREFIX}6/14/2026`,
+    );
+  });
+
+  it("handles single-digit month/day", () => {
+    expect(buildRevParHeader("2026-01-05")).toBe(
+      `${REVPAR_HEADER_PREFIX}1/5/2026`,
+    );
+  });
+});
+
+// ─── transformJournalSummaryToJERecords ───────────────────────────────────────
+
+describe("transformJournalSummaryToJERecords", () => {
+  const MISSOULA = "Comfort Inn - Missoula";
+
+  const baseSummary: JournalSummaryData = {
+    transactions: [
+      {
+        transactionCode: "RM",
+        totals: 8355.4,
+        guestLedger: 8355.4,
+        arLedger: 0,
+        advDepLedger: 0,
+      },
+      {
+        transactionCode: "AX",
+        totals: -3789.05,
+        guestLedger: -3789.05,
+        arLedger: 0,
+        advDepLedger: 0,
+      },
+      {
+        transactionCode: "T1",
+        totals: 551.92,
+        guestLedger: 551.92,
+        arLedger: 0,
+        advDepLedger: 0,
+      },
+    ],
+    guestLedgerSum: -14426.4,
+    arLedgerSum: 0,
+    advDepLedgerSum: 316.34,
+  };
+
+  it("emits a JE record for a globally mapped transaction code", async () => {
+    const mapping = await buildMapping([
+      ["RM", "ROOM CHARGE", 1, null, "40110-634", "Room Revenue", "Accounting"],
+    ]);
+    const records = transformJournalSummaryToJERecords(
+      baseSummary,
+      mapping,
+      MISSOULA,
+    );
+    expect(records).toHaveLength(1);
+    expect(records[0].targetCode).toBe("40110-634");
+    expect(records[0].mappedAmount).toBeCloseTo(8355.4);
+    expect(records[0].sourceDescription).toBe("ROOM CHARGE");
+  });
+
+  it("applies the multiplier from the mapping", async () => {
+    const mapping = await buildMapping([
+      [
+        "AX",
+        "AMERICAN EXPRESS",
+        -1,
+        MISSOULA,
+        "10190-718",
+        "Cash",
+        "Accounting",
+      ],
+    ]);
+    const records = transformJournalSummaryToJERecords(
+      baseSummary,
+      mapping,
+      MISSOULA,
+    );
+    expect(records).toHaveLength(1);
+    // -3789.05 × -1 = 3789.05
+    expect(records[0].mappedAmount).toBeCloseTo(3789.05);
+  });
+
+  it("resolves property-specific entry over global entry", async () => {
+    const mapping = await buildMapping([
+      ["AX", "AMEX", -1, MISSOULA, "10190-718", "CashMis", "Accounting"],
+      [
+        "AX",
+        "AMEX",
+        -1,
+        "Comfort Inn & Suites - Ashland",
+        "10090-701",
+        "CashAsh",
+        "Accounting",
+      ],
+    ]);
+    const records = transformJournalSummaryToJERecords(
+      baseSummary,
+      mapping,
+      MISSOULA,
+    );
+    expect(records[0].targetCode).toBe("10190-718");
+  });
+
+  it("skips transactions with zero net amount after multiplier", async () => {
+    const zeroSummary: JournalSummaryData = {
+      transactions: [
+        {
+          transactionCode: "RM",
+          totals: 0,
+          guestLedger: 0,
+          arLedger: 0,
+          advDepLedger: 0,
+        },
+      ],
+      guestLedgerSum: 0,
+      arLedgerSum: 0,
+      advDepLedgerSum: 0,
+    };
+    const mapping = await buildMapping([
+      ["RM", "ROOM CHARGE", 1, null, "40110-634", "Room Revenue", "Accounting"],
+    ]);
+    expect(
+      transformJournalSummaryToJERecords(zeroSummary, mapping, MISSOULA),
+    ).toHaveLength(0);
+  });
+
+  it("skips unmapped transaction codes", async () => {
+    const mapping = await buildMapping([
+      ["RM", "ROOM CHARGE", 1, null, "40110-634", "Room Revenue", "Accounting"],
+    ]);
+    const summaryWithUnmapped: JournalSummaryData = {
+      ...baseSummary,
+      transactions: [
+        {
+          transactionCode: "RM",
+          totals: 100,
+          guestLedger: 100,
+          arLedger: 0,
+          advDepLedger: 0,
+        },
+        {
+          transactionCode: "UNKNOWN",
+          totals: 50,
+          guestLedger: 50,
+          arLedger: 0,
+          advDepLedger: 0,
+        },
+      ],
+    };
+    const records = transformJournalSummaryToJERecords(
+      summaryWithUnmapped,
+      mapping,
+      MISSOULA,
+    );
+    expect(records.map((r) => r.sourceCode)).not.toContain("UNKNOWN");
+  });
+
+  it("skips transaction code mapped to CHOICE_NOT_MAPPED", async () => {
+    const mapping = await buildMapping([
+      ["RM", "ROOM CHARGE", 1, null, "", "Room Revenue", "Accounting"],
+    ]);
+    const records = transformJournalSummaryToJERecords(
+      baseSummary,
+      mapping,
+      MISSOULA,
+    );
+    expect(records.map((r) => r.sourceCode)).not.toContain("RM");
+  });
+
+  it("skips ledger key mapped to CHOICE_NOT_MAPPED", async () => {
+    const mapping = await buildMapping([
+      [
+        "Guest Ledger",
+        "Guest Ledger Sum",
+        1,
+        null,
+        "",
+        "Guest Ledger",
+        "Accounting",
+      ],
+    ]);
+    const records = transformJournalSummaryToJERecords(
+      baseSummary,
+      mapping,
+      MISSOULA,
+    );
+    expect(records).toHaveLength(0);
+  });
+
+  it("emits Guest Ledger record from column sum", async () => {
+    const mapping = await buildMapping([
+      [
+        "Guest Ledger",
+        "Sum of Guest Ledger Column",
+        1,
+        null,
+        "10006-654",
+        "Guest Ledger",
+        "Accounting",
+      ],
+    ]);
+    const records = transformJournalSummaryToJERecords(
+      baseSummary,
+      mapping,
+      MISSOULA,
+    );
+    expect(records).toHaveLength(1);
+    expect(records[0].targetCode).toBe("10006-654");
+    expect(records[0].mappedAmount).toBeCloseTo(-14426.4);
+  });
+
+  it("emits AdvDep Ledger record from column sum", async () => {
+    const mapping = await buildMapping([
+      [
+        "AdvDep Ledger",
+        "Sum of AdvDep Ledger Column",
+        1,
+        null,
+        "24000-263",
+        "Deferred Revenue",
+        "Accounting",
+      ],
+    ]);
+    const records = transformJournalSummaryToJERecords(
+      baseSummary,
+      mapping,
+      MISSOULA,
+    );
+    expect(records).toHaveLength(1);
+    expect(records[0].mappedAmount).toBeCloseTo(316.34);
+  });
+
+  it("skips AR Ledger when sum is zero", async () => {
+    const mapping = await buildMapping([
+      [
+        "AR Ledger",
+        "Sum of AR Ledger Column",
+        1,
+        null,
+        "10502-2051",
+        "City Ledger",
+        "Accounting",
+      ],
+    ]);
+    const records = transformJournalSummaryToJERecords(
+      baseSummary,
+      mapping,
+      MISSOULA,
+    );
+    // arLedgerSum = 0 → should be skipped
+    expect(records).toHaveLength(0);
+  });
+
+  it("does not emit Statistical entries", async () => {
+    const mapping = await buildMapping([
+      ["RM", "ROOM CHARGE", 1, null, "40110-634", "Room Revenue", "Accounting"],
+      [
+        "Occupancy Statistics_ADR for Total Occupied Rooms",
+        "ADR",
+        1,
+        null,
+        "90001-418",
+        "ADR",
+        "Statistical",
+      ],
+    ]);
+    const records = transformJournalSummaryToJERecords(
+      baseSummary,
+      mapping,
+      MISSOULA,
+    );
+    const statRecords = records.filter((r) => r.targetCode?.startsWith("90"));
+    expect(statRecords).toHaveLength(0);
+  });
+});
+
+// ─── transformHotelStatsToStatJERecords ───────────────────────────────────────
+
+describe("transformHotelStatsToStatJERecords", () => {
+  const businessDate = "2026-06-14";
+  const revParHeader = buildRevParHeader(businessDate);
+
+  const baseStats: HotelStatsData = {
+    businessDate,
+    columns: new Map([
+      ["Room Statistics_Total Rooms", "61"],
+      ["Total Occupied Rooms", "37"],
+      ["Comp Rooms", "0"],
+      ["Occupancy Statistics_Occ% of Total Rooms", "60.66%"],
+      ["Occupancy Statistics_ADR for Total Occupied Rooms", "202.52"],
+      [revParHeader, "122.84"],
+      ["Room Statistics_Out Of Order", "0"],
+    ]),
+  };
+
+  it("emits ADR record with correct amount", async () => {
+    const mapping = await buildMapping([
+      [
+        "Occupancy Statistics_ADR for Total Occupied Rooms",
+        "ADR",
+        1,
+        null,
+        "90001-418",
+        "ADR",
+        "Statistical",
+      ],
+    ]);
+    const records = transformHotelStatsToStatJERecords(baseStats, mapping);
+    const adr = records.find((r) => r.targetCode === "90001-418");
+    expect(adr?.mappedAmount).toBeCloseTo(202.52);
+  });
+
+  it("strips percentage sign when parsing Occupancy", async () => {
+    const mapping = await buildMapping([
+      [
+        "Occupancy Statistics_Occ% of Total Rooms",
+        "Occupancy",
+        1,
+        null,
+        "90002-419",
+        "Occy",
+        "Statistical",
+      ],
+    ]);
+    const records = transformHotelStatsToStatJERecords(baseStats, mapping);
+    const occy = records.find((r) => r.targetCode === "90002-419");
+    expect(occy?.mappedAmount).toBeCloseTo(60.66);
+  });
+
+  it("resolves RevPAR via date-based prefix matching", async () => {
+    const mapping = await buildMapping([
+      [
+        `Occupancy Statistics_RevPar_(Date)`,
+        "REVPAR",
+        1,
+        null,
+        "90003-420",
+        "RevPAR",
+        "Statistical",
+      ],
+    ]);
+    const records = transformHotelStatsToStatJERecords(baseStats, mapping);
+    const revpar = records.find((r) => r.targetCode === "90003-420");
+    expect(revpar?.mappedAmount).toBeCloseTo(122.84);
+  });
+
+  it("always appends three trailing zero rows", async () => {
+    const mapping = await buildMapping([
+      [
+        "Occupancy Statistics_ADR for Total Occupied Rooms",
+        "ADR",
+        1,
+        null,
+        "90001-418",
+        "ADR",
+        "Statistical",
+      ],
+      [
+        "Occupancy Statistics_Occ% of Total Rooms",
+        "Occupancy",
+        1,
+        null,
+        "90002-419",
+        "Occy",
+        "Statistical",
+      ],
+      [
+        `Occupancy Statistics_RevPar_(Date)`,
+        "REVPAR",
+        1,
+        null,
+        "90003-420",
+        "RevPAR",
+        "Statistical",
+      ],
+    ]);
+    const records = transformHotelStatsToStatJERecords(baseStats, mapping);
+
+    // 3 real records + 3 trailing zero rows = 6
+    expect(records).toHaveLength(6);
+
+    const lastThree = records.slice(-3);
+    expect(lastThree.every((r) => r.mappedAmount === 0)).toBe(true);
+    expect(lastThree.map((r) => r.targetCode)).toEqual([
+      "90002-419", // Occy
+      "90001-418", // ADR
+      "90003-420", // RevPAR
+    ]);
+  });
+
+  it("skips stat entries with no matching column in stats file", async () => {
+    const mapping = await buildMapping([
+      [
+        "NonExistentColumn",
+        "Missing",
+        1,
+        null,
+        "90009-633",
+        "Rooms Available",
+        "Statistical",
+      ],
+    ]);
+    const records = transformHotelStatsToStatJERecords(baseStats, mapping);
+    // Only the 3 trailing rows should be emitted
+    expect(records).toHaveLength(3);
+    expect(records.every((r) => r.mappedAmount === 0)).toBe(true);
+  });
+
+  it("does not emit Accounting entries", async () => {
+    const mapping = await buildMapping([
+      ["RM", "ROOM CHARGE", 1, null, "40110-634", "Room Revenue", "Accounting"],
+    ]);
+    const records = transformHotelStatsToStatJERecords(baseStats, mapping);
+    // Only trailing zeros — no accounting records
+    const accountingRecords = records.filter(
+      (r) => !r.targetCode?.startsWith("90"),
+    );
+    expect(accountingRecords).toHaveLength(0);
+  });
+
+  it("skips Statistical entry mapped to CHOICE_NOT_MAPPED", async () => {
+    const mapping = await buildMapping([
+      [
+        "Occupancy Statistics_ADR for Total Occupied Rooms",
+        "ADR",
+        1,
+        null,
+        "",
+        "ADR",
+        "Statistical",
+      ],
+    ]);
+    const records = transformHotelStatsToStatJERecords(baseStats, mapping);
+    // All three trailing zeros should still be emitted; the ADR stat entry itself skipped
+    expect(records.every((r) => r.mappedAmount === 0)).toBe(true);
+  });
+});

--- a/src/choice/choice-transformation.test.ts
+++ b/src/choice/choice-transformation.test.ts
@@ -308,6 +308,187 @@ describe("transformJournalSummaryToJERecords", () => {
     expect(records).toHaveLength(0);
   });
 
+  describe("combined Visa/MasterCard/Discover row", () => {
+    const cardSummary: JournalSummaryData = {
+      transactions: [
+        {
+          transactionCode: "VI",
+          totals: 1000,
+          guestLedger: 1000,
+          arLedger: 0,
+          advDepLedger: 0,
+        },
+        {
+          transactionCode: "MC",
+          totals: 500,
+          guestLedger: 500,
+          arLedger: 0,
+          advDepLedger: 0,
+        },
+        {
+          transactionCode: "DS",
+          totals: 250,
+          guestLedger: 250,
+          arLedger: 0,
+          advDepLedger: 0,
+        },
+        {
+          transactionCode: "AX",
+          totals: 300,
+          guestLedger: 300,
+          arLedger: 0,
+          advDepLedger: 0,
+        },
+      ],
+      guestLedgerSum: 0,
+      arLedgerSum: 0,
+      advDepLedgerSum: 0,
+    };
+
+    it("combines VI, MC, and DS into a single row when they resolve to the same account", async () => {
+      const mapping = await buildMapping([
+        ["VI", "VISA", 1, null, "10190-718", "Cash", "Accounting"],
+        ["MC", "MASTERCARD", 1, null, "10190-718", "Cash", "Accounting"],
+        ["DS", "DISCOVER", 1, null, "10190-718", "Cash", "Accounting"],
+        ["AX", "AMEX", 1, null, "10190-718", "Cash", "Accounting"],
+      ]);
+      const records = transformJournalSummaryToJERecords(
+        cardSummary,
+        mapping,
+        MISSOULA,
+      );
+
+      const cardRows = records.filter((r) => r.targetCode === "10190-718");
+      // 1 combined VI+MC+DS row + 1 separate AX row = 2
+      expect(cardRows).toHaveLength(2);
+
+      const combined = records.find((r) => r.sourceCode === "VI+MC+DS");
+      expect(combined?.mappedAmount).toBeCloseTo(1750); // 1000 + 500 + 250
+      expect(combined?.paymentMethod).toBe("Visa/MC/Discover");
+
+      const ax = records.find((r) => r.sourceCode === "AX");
+      expect(ax?.mappedAmount).toBeCloseTo(300);
+      expect(ax?.paymentMethod).toBe("American Express");
+
+      // Individual VI/MC/DS rows must not also appear
+      expect(records.map((r) => r.sourceCode)).not.toContain("VI");
+      expect(records.map((r) => r.sourceCode)).not.toContain("MC");
+      expect(records.map((r) => r.sourceCode)).not.toContain("DS");
+    });
+
+    it("combines just two of the three codes when only two are present", async () => {
+      const twoCardSummary: JournalSummaryData = {
+        ...cardSummary,
+        transactions: cardSummary.transactions.filter(
+          (t) => t.transactionCode !== "DS",
+        ),
+      };
+      const mapping = await buildMapping([
+        ["VI", "VISA", 1, null, "10190-718", "Cash", "Accounting"],
+        ["MC", "MASTERCARD", 1, null, "10190-718", "Cash", "Accounting"],
+      ]);
+      const records = transformJournalSummaryToJERecords(
+        twoCardSummary,
+        mapping,
+        MISSOULA,
+      );
+
+      const combined = records.find((r) => r.sourceCode === "VI+MC+DS");
+      expect(combined?.mappedAmount).toBeCloseTo(1500); // 1000 + 500
+    });
+
+    it("does not combine when only one of the three codes is present", async () => {
+      const oneCardSummary: JournalSummaryData = {
+        ...cardSummary,
+        transactions: cardSummary.transactions.filter(
+          (t) => t.transactionCode === "VI",
+        ),
+      };
+      const mapping = await buildMapping([
+        ["VI", "VISA", 1, null, "10190-718", "Cash", "Accounting"],
+      ]);
+      const records = transformJournalSummaryToJERecords(
+        oneCardSummary,
+        mapping,
+        MISSOULA,
+      );
+
+      expect(records).toHaveLength(1);
+      expect(records[0].sourceCode).toBe("VI");
+      expect(records[0].paymentMethod).toBeUndefined();
+      expect(records[0].mappedAmount).toBeCloseTo(1000);
+    });
+
+    it("falls back to individual rows when the codes resolve to different accounts", async () => {
+      const mapping = await buildMapping([
+        ["VI", "VISA", 1, null, "10190-718", "Cash", "Accounting"],
+        ["MC", "MASTERCARD", 1, null, "10190-718", "Cash", "Accounting"],
+        ["DS", "DISCOVER", 1, null, "10200-999", "Other Cash", "Accounting"],
+      ]);
+      const records = transformJournalSummaryToJERecords(
+        cardSummary,
+        mapping,
+        MISSOULA,
+      );
+
+      expect(records.map((r) => r.sourceCode)).not.toContain("VI+MC+DS");
+      expect(records.map((r) => r.sourceCode)).toContain("VI");
+      expect(records.map((r) => r.sourceCode)).toContain("MC");
+      expect(records.map((r) => r.sourceCode)).toContain("DS");
+    });
+
+    it("omits the combined row entirely when the combined amount nets to zero", async () => {
+      const zeroNetSummary: JournalSummaryData = {
+        ...cardSummary,
+        transactions: [
+          {
+            transactionCode: "VI",
+            totals: 100,
+            guestLedger: 100,
+            arLedger: 0,
+            advDepLedger: 0,
+          },
+          {
+            transactionCode: "MC",
+            totals: -100,
+            guestLedger: -100,
+            arLedger: 0,
+            advDepLedger: 0,
+          },
+        ],
+      };
+      const mapping = await buildMapping([
+        ["VI", "VISA", 1, null, "10190-718", "Cash", "Accounting"],
+        ["MC", "MASTERCARD", 1, null, "10190-718", "Cash", "Accounting"],
+      ]);
+      const records = transformJournalSummaryToJERecords(
+        zeroNetSummary,
+        mapping,
+        MISSOULA,
+      );
+
+      expect(records).toHaveLength(0);
+    });
+
+    it("does not combine codes mapped to CHOICE_NOT_MAPPED", async () => {
+      const mapping = await buildMapping([
+        ["VI", "VISA", 1, null, "10190-718", "Cash", "Accounting"],
+        ["MC", "MASTERCARD", 1, null, "", "Cash", "Accounting"],
+        ["DS", "DISCOVER", 1, null, "10190-718", "Cash", "Accounting"],
+      ]);
+      const records = transformJournalSummaryToJERecords(
+        cardSummary,
+        mapping,
+        MISSOULA,
+      );
+
+      // MC is not mapped, so only VI + DS are eligible to combine.
+      const combined = records.find((r) => r.sourceCode === "VI+MC+DS");
+      expect(combined?.mappedAmount).toBeCloseTo(1250); // 1000 + 250
+      expect(records.map((r) => r.sourceCode)).not.toContain("MC");
+    });
+  });
+
   it("does not emit Statistical entries", async () => {
     const mapping = await buildMapping([
       ["RM", "ROOM CHARGE", 1, null, "40110-634", "Room Revenue", "Accounting"],
@@ -401,7 +582,7 @@ describe("transformHotelStatsToStatJERecords", () => {
     expect(revpar?.mappedAmount).toBeCloseTo(122.84);
   });
 
-  it("always appends three trailing zero rows", async () => {
+  it("does not duplicate Occy/ADR/RevPAR with a trailing zero row when real values are already present", async () => {
     const mapping = await buildMapping([
       [
         "Occupancy Statistics_ADR for Total Occupied Rooms",
@@ -433,16 +614,42 @@ describe("transformHotelStatsToStatJERecords", () => {
     ]);
     const records = transformHotelStatsToStatJERecords(baseStats, mapping);
 
-    // 3 real records + 3 trailing zero rows = 6
-    expect(records).toHaveLength(6);
-
-    const lastThree = records.slice(-3);
-    expect(lastThree.every((r) => r.mappedAmount === 0)).toBe(true);
-    expect(lastThree.map((r) => r.targetCode)).toEqual([
-      "90002-419", // Occy
+    // Only the 3 real records — no duplicate zero-value rows appended.
+    expect(records).toHaveLength(3);
+    expect(records.every((r) => r.mappedAmount !== 0)).toBe(true);
+    expect(records.map((r) => r.targetCode).sort()).toEqual([
       "90001-418", // ADR
+      "90002-419", // Occy
       "90003-420", // RevPAR
     ]);
+  });
+
+  it("appends a trailing zero row only for the GL codes missing a real value", async () => {
+    // Only ADR is mapped/resolved; Occy and RevPAR have no mapping entry at all,
+    // so they should each fall back to their trailing zero placeholder row.
+    const mapping = await buildMapping([
+      [
+        "Occupancy Statistics_ADR for Total Occupied Rooms",
+        "ADR",
+        1,
+        null,
+        "90001-418",
+        "ADR",
+        "Statistical",
+      ],
+    ]);
+    const records = transformHotelStatsToStatJERecords(baseStats, mapping);
+
+    expect(records).toHaveLength(3);
+
+    const adr = records.find((r) => r.targetCode === "90001-418");
+    expect(adr?.mappedAmount).toBeCloseTo(202.52);
+
+    const occy = records.find((r) => r.targetCode === "90002-419");
+    expect(occy?.mappedAmount).toBe(0);
+
+    const revpar = records.find((r) => r.targetCode === "90003-420");
+    expect(revpar?.mappedAmount).toBe(0);
   });
 
   it("skips stat entries with no matching column in stats file", async () => {

--- a/src/choice/choice-transformation.ts
+++ b/src/choice/choice-transformation.ts
@@ -1,0 +1,232 @@
+/**
+ * @fileoverview Choice Hotels Transformation
+ *
+ * Converts parsed Journal Summary and Hotel Statistics data into the
+ * TransformedJERecord / TransformedStatJERecord shapes consumed by the
+ * existing JournalEntryGenerator and StatisticalEntryGenerator.
+ *
+ * JE transformation rules:
+ *  • For most transaction codes the amount comes from the "Totals" column.
+ *  • Guest Ledger, AR Ledger, and AdvDep Ledger use the *column sum* across
+ *    all rows — these are mapped via special keys in the mapping file.
+ *  • The multiplier from the mapping is applied before emitting the record.
+ *  • Rows that resolve to CHOICE_NOT_MAPPED or that have zero net amounts
+ *    are omitted.
+ *
+ * StatJE transformation rules:
+ *  • Each Statistical mapping entry is looked up against the Hotel Statistics
+ *    column map (exact match, except RevPAR which uses prefix matching).
+ *  • Percentage values (e.g. "60.66%") are stripped of the "%" before parsing.
+ *  • Three trailing zero rows are emitted for Occupancy, ADR, and RevPAR —
+ *    these are required placeholder rows in the NetSuite StatJE import.
+ */
+
+import { JournalSummaryData } from "./choice-journal-summary-parser";
+import {
+  HotelStatsData,
+  getRevParValue,
+  REVPAR_HEADER_PREFIX,
+} from "./choice-hotel-stats-parser";
+import {
+  ChoiceMapping,
+  ChoiceMappingEntry,
+  CHOICE_NOT_MAPPED,
+  REVPAR_DATE_PLACEHOLDER,
+  findChoiceMappingEntry,
+} from "./choice-mapping-loader";
+import { TransformedJERecord } from "../output/journal-entry-generator";
+import { TransformedStatJERecord } from "../output/statistical-entry-generator";
+
+// ─── Ledger source codes ──────────────────────────────────────────────────────
+
+/** Keys in the mapping file that correspond to Journal Summary ledger column sums */
+const LEDGER_KEYS = ["Guest Ledger", "AR Ledger", "AdvDep Ledger"] as const;
+type LedgerKey = (typeof LEDGER_KEYS)[number];
+
+// ─── StatJE trailing rows ─────────────────────────────────────────────────────
+
+/**
+ * Three placeholder StatJE rows appended after the real stat records.
+ * NetSuite expects these rows to be present even when values are zero.
+ */
+const TRAILING_STAT_ROWS: Array<{ glAcctCode: string; glAcctName: string }> = [
+  { glAcctCode: "90002-419", glAcctName: "Occy" },
+  { glAcctCode: "90001-418", glAcctName: "ADR" },
+  { glAcctCode: "90003-420", glAcctName: "RevPAR" },
+];
+
+// ─── Public helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Transform a parsed Journal Summary into JE records suitable for the
+ * JournalEntryGenerator.
+ *
+ * @param journalSummary - Parsed Journal Summary file
+ * @param mapping - Full Choice mapping
+ * @param mappingPropertyName - Display name as it appears in the mapping workbook
+ *        (e.g. "Comfort Inn - Missoula").  Used to resolve property-specific
+ *        cash-in-bank accounts.
+ * @returns Array of transformed JE records
+ */
+export function transformJournalSummaryToJERecords(
+  journalSummary: JournalSummaryData,
+  mapping: ChoiceMapping,
+  mappingPropertyName: string,
+): TransformedJERecord[] {
+  const records: TransformedJERecord[] = [];
+
+  // ── Standard transaction code rows ──────────────────────────────────────────
+  for (const tx of journalSummary.transactions) {
+    const entry = findChoiceMappingEntry(
+      mapping,
+      tx.transactionCode,
+      mappingPropertyName,
+    );
+
+    if (!entry) continue;
+    if (entry.glAcctCode === CHOICE_NOT_MAPPED) continue;
+
+    const rawAmount = tx.totals * entry.multiplier;
+    if (rawAmount === 0) continue;
+
+    records.push(buildJERecord(tx.transactionCode, entry, rawAmount));
+  }
+
+  // ── Ledger column sums ───────────────────────────────────────────────────────
+  const ledgerSums: Record<LedgerKey, number> = {
+    "Guest Ledger": journalSummary.guestLedgerSum,
+    "AR Ledger": journalSummary.arLedgerSum,
+    "AdvDep Ledger": journalSummary.advDepLedgerSum,
+  };
+
+  for (const key of LEDGER_KEYS) {
+    const sum = ledgerSums[key];
+    if (sum === 0) continue;
+
+    const entry = findChoiceMappingEntry(mapping, key, mappingPropertyName);
+    if (!entry) continue;
+    if (entry.glAcctCode === CHOICE_NOT_MAPPED) continue;
+
+    const rawAmount = sum * entry.multiplier;
+    if (rawAmount === 0) continue;
+
+    records.push(buildJERecord(key, entry, rawAmount));
+  }
+
+  return records;
+}
+
+/**
+ * Transform parsed Hotel Statistics into StatJE records suitable for the
+ * StatisticalEntryGenerator.
+ *
+ * Three trailing zero-value rows (Occy, ADR, RevPAR) are always appended.
+ *
+ * @param statsData - Parsed Hotel Statistics file
+ * @param mapping - Full Choice mapping
+ * @returns Array of transformed StatJE records (real + trailing zeros)
+ */
+export function transformHotelStatsToStatJERecords(
+  statsData: HotelStatsData,
+  mapping: ChoiceMapping,
+): TransformedStatJERecord[] {
+  const records: TransformedStatJERecord[] = [];
+
+  for (const [srcCode, entries] of mapping.entries()) {
+    const entry = entries[0]; // Statistical entries are always global (no property filter needed)
+    if (!entry || entry.acctType !== "Statistical") continue;
+    if (entry.glAcctCode === CHOICE_NOT_MAPPED) continue;
+
+    // Resolve the actual column value from the stats file
+    const rawValue = resolveStatColumn(srcCode, statsData);
+    if (rawValue === undefined) continue;
+
+    const amount = parseStatAmount(rawValue);
+    const mappedAmount = amount * entry.multiplier;
+
+    records.push({
+      sourceCode: srcCode,
+      sourceDescription: entry.glAcctName,
+      sourceAmount: mappedAmount,
+      targetCode: entry.glAcctCode,
+      targetDescription: entry.glAcctName,
+      mappedAmount,
+    });
+  }
+
+  // Always append three trailing zero rows (Occy, ADR, RevPAR).
+  // These are required placeholder rows for the NetSuite StatJE import
+  // even when the real values are already present above.
+  for (const { glAcctCode, glAcctName } of TRAILING_STAT_ROWS) {
+    records.push({
+      sourceCode: glAcctCode,
+      sourceDescription: glAcctName,
+      sourceAmount: 0,
+      targetCode: glAcctCode,
+      targetDescription: glAcctName,
+      mappedAmount: 0,
+    });
+  }
+
+  return records;
+}
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
+/** Build a TransformedJERecord from a mapping entry and computed amount */
+function buildJERecord(
+  sourceCode: string,
+  entry: ChoiceMappingEntry,
+  amount: number,
+): TransformedJERecord {
+  return {
+    sourceCode,
+    sourceDescription: entry.srcDesc,
+    sourceAmount: amount,
+    targetCode: entry.glAcctCode,
+    targetDescription: entry.glAcctName,
+    mappedAmount: amount,
+  };
+}
+
+/**
+ * Resolve the raw string value for a statistical mapping entry.
+ *
+ * The RevPAR mapping key in the workbook ends with `(Date)`, which is a
+ * placeholder for the actual business date embedded in the column header.
+ * All other keys must match exactly.
+ */
+function resolveStatColumn(
+  srcCode: string,
+  statsData: HotelStatsData,
+): string | undefined {
+  // RevPAR: strip the (Date) placeholder and use prefix matching
+  if (srcCode.endsWith(REVPAR_DATE_PLACEHOLDER)) {
+    return getRevParValue(statsData);
+  }
+
+  // Otherwise look up by the column's exact header name
+  return statsData.columns.get(srcCode);
+}
+
+/**
+ * Parse a statistical value that may include a trailing "%" character.
+ * Examples: "60.66%", "202.52", "37", "0"
+ */
+export function parseStatAmount(raw: string): number {
+  const stripped = raw.trim().replace(/%$/, "");
+  return parseFloat(stripped) || 0;
+}
+
+/**
+ * Derive the RevPAR column header for a given date.
+ * Used in tests and documentation.
+ *
+ * @param businessDate - YYYY-MM-DD format
+ * @returns Full column header e.g. "Occupancy Statistics_RevPar_6/23/2026"
+ */
+export function buildRevParHeader(businessDate: string): string {
+  const [year, month, day] = businessDate.split("-");
+  // Format: M/D/YYYY (no zero-padding, matching Choice Hotels output)
+  return `${REVPAR_HEADER_PREFIX}${parseInt(month, 10)}/${parseInt(day, 10)}/${year}`;
+}

--- a/src/choice/choice-transformation.ts
+++ b/src/choice/choice-transformation.ts
@@ -17,8 +17,11 @@
  *  • Each Statistical mapping entry is looked up against the Hotel Statistics
  *    column map (exact match, except RevPAR which uses prefix matching).
  *  • Percentage values (e.g. "60.66%") are stripped of the "%" before parsing.
- *  • Three trailing zero rows are emitted for Occupancy, ADR, and RevPAR —
- *    these are required placeholder rows in the NetSuite StatJE import.
+ *  • Occupancy, ADR, and RevPAR are required placeholder rows in the NetSuite
+ *    StatJE import: a trailing zero row is appended for each of these three
+ *    GL codes only if a real (mapped) value wasn't already emitted above —
+ *    this is a safety net for a missing mapping/stats column, not a row that
+ *    should ever duplicate a real value.
  */
 
 import { JournalSummaryData } from "./choice-journal-summary-parser";
@@ -43,11 +46,32 @@ import { TransformedStatJERecord } from "../output/statistical-entry-generator";
 const LEDGER_KEYS = ["Guest Ledger", "AR Ledger", "AdvDep Ledger"] as const;
 type LedgerKey = (typeof LEDGER_KEYS)[number];
 
+// ─── Combined credit card codes ───────────────────────────────────────────────
+
+/**
+ * Transaction codes combined into a single "Visa/MC/Discover" JE line, mirroring
+ * the existing convention in credit-card-processor.ts (Visual Matrix) and
+ * opera-transformation.ts (Opera): these three settle together on the bank
+ * statement, so combining them lets the hotel's accounting system auto-match
+ * the deposit. American Express is intentionally excluded — it settles
+ * separately from the Visa/MC/Discover batch.
+ *
+ * Combining only happens when 2+ of these codes are present in the Journal
+ * Summary file AND all resolve to the same GL account for the property; if
+ * either condition fails, each code falls back to its own row (unchanged
+ * behavior), so this can never silently merge amounts into the wrong account.
+ */
+const COMBINED_CARD_CODES = new Set(["VI", "MC", "DS"]);
+const COMBINED_CARD_LABEL = "Visa/MC/Discover";
+
 // ─── StatJE trailing rows ─────────────────────────────────────────────────────
 
 /**
- * Three placeholder StatJE rows appended after the real stat records.
- * NetSuite expects these rows to be present even when values are zero.
+ * Placeholder StatJE rows appended after the real stat records, but only for
+ * a GL code that wasn't already emitted with a real value. NetSuite expects
+ * these rows to be present even when the mapping/stats data is missing them,
+ * but the Choice mapping always provides real values for Occy/ADR/RevPAR, so
+ * in practice these rows are almost never actually emitted.
  */
 const TRAILING_STAT_ROWS: Array<{ glAcctCode: string; glAcctName: string }> = [
   { glAcctCode: "90002-419", glAcctName: "Occy" },
@@ -75,8 +99,59 @@ export function transformJournalSummaryToJERecords(
 ): TransformedJERecord[] {
   const records: TransformedJERecord[] = [];
 
+  // ── Combined Visa/MasterCard/Discover row ───────────────────────────────────
+  // See COMBINED_CARD_CODES doc comment above for the rationale and fallback
+  // conditions. cardsResolveToSameAccount starts true and is only flipped to
+  // false if two of the codes resolve to different GL accounts.
+  const cardAmounts: number[] = [];
+  let combinedCardEntry: ChoiceMappingEntry | undefined;
+  let cardsResolveToSameAccount = true;
+
+  for (const tx of journalSummary.transactions) {
+    if (!COMBINED_CARD_CODES.has(tx.transactionCode)) continue;
+
+    const entry = findChoiceMappingEntry(
+      mapping,
+      tx.transactionCode,
+      mappingPropertyName,
+    );
+    if (!entry || entry.glAcctCode === CHOICE_NOT_MAPPED) continue;
+
+    if (
+      combinedCardEntry &&
+      entry.glAcctCode !== combinedCardEntry.glAcctCode
+    ) {
+      cardsResolveToSameAccount = false;
+    }
+    combinedCardEntry = entry;
+    cardAmounts.push(tx.totals * entry.multiplier);
+  }
+
+  const shouldCombineCards =
+    cardsResolveToSameAccount && cardAmounts.length >= 2 && !!combinedCardEntry;
+
+  if (shouldCombineCards && combinedCardEntry) {
+    const combinedAmount = cardAmounts.reduce((sum, a) => sum + a, 0);
+    if (combinedAmount !== 0) {
+      records.push({
+        sourceCode: "VI+MC+DS",
+        sourceDescription: COMBINED_CARD_LABEL,
+        sourceAmount: combinedAmount,
+        targetCode: combinedCardEntry.glAcctCode,
+        targetDescription: combinedCardEntry.glAcctName,
+        mappedAmount: combinedAmount,
+        paymentMethod: COMBINED_CARD_LABEL,
+      });
+    }
+  }
+
   // ── Standard transaction code rows ──────────────────────────────────────────
   for (const tx of journalSummary.transactions) {
+    // Visa/MC/Discover are already accounted for in the combined row above.
+    if (shouldCombineCards && COMBINED_CARD_CODES.has(tx.transactionCode)) {
+      continue;
+    }
+
     const entry = findChoiceMappingEntry(
       mapping,
       tx.transactionCode,
@@ -89,7 +164,12 @@ export function transformJournalSummaryToJERecords(
     const rawAmount = tx.totals * entry.multiplier;
     if (rawAmount === 0) continue;
 
-    records.push(buildJERecord(tx.transactionCode, entry, rawAmount));
+    const paymentMethod =
+      tx.transactionCode === "AX" ? "American Express" : undefined;
+
+    records.push(
+      buildJERecord(tx.transactionCode, entry, rawAmount, paymentMethod),
+    );
   }
 
   // ── Ledger column sums ───────────────────────────────────────────────────────
@@ -120,11 +200,13 @@ export function transformJournalSummaryToJERecords(
  * Transform parsed Hotel Statistics into StatJE records suitable for the
  * StatisticalEntryGenerator.
  *
- * Three trailing zero-value rows (Occy, ADR, RevPAR) are always appended.
+ * A trailing zero-value row for Occy, ADR, or RevPAR is appended only when a
+ * real record for that GL code wasn't already emitted (see TRAILING_STAT_ROWS
+ * doc comment) — real records are never duplicated by a zero-value row.
  *
  * @param statsData - Parsed Hotel Statistics file
  * @param mapping - Full Choice mapping
- * @returns Array of transformed StatJE records (real + trailing zeros)
+ * @returns Array of transformed StatJE records (real values + any missing placeholders)
  */
 export function transformHotelStatsToStatJERecords(
   statsData: HotelStatsData,
@@ -154,10 +236,13 @@ export function transformHotelStatsToStatJERecords(
     });
   }
 
-  // Always append three trailing zero rows (Occy, ADR, RevPAR).
-  // These are required placeholder rows for the NetSuite StatJE import
-  // even when the real values are already present above.
+  // Append a trailing zero row for Occy/ADR/RevPAR only when a real record
+  // for that GL code wasn't already emitted above. This is a safety net for
+  // a missing mapping/stats column — it must never duplicate a real value.
+  const emittedTargetCodes = new Set(records.map((r) => r.targetCode));
   for (const { glAcctCode, glAcctName } of TRAILING_STAT_ROWS) {
+    if (emittedTargetCodes.has(glAcctCode)) continue;
+
     records.push({
       sourceCode: glAcctCode,
       sourceDescription: glAcctName,
@@ -178,6 +263,7 @@ function buildJERecord(
   sourceCode: string,
   entry: ChoiceMappingEntry,
   amount: number,
+  paymentMethod?: string,
 ): TransformedJERecord {
   return {
     sourceCode,
@@ -186,6 +272,7 @@ function buildJERecord(
     targetCode: entry.glAcctCode,
     targetDescription: entry.glAcctName,
     mappedAmount: amount,
+    paymentMethod,
   };
 }
 

--- a/src/choice/index.ts
+++ b/src/choice/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Choice Hotels pipeline — public exports
+ */
+
+export {
+  parseJournalSummary,
+  parseAmount,
+  parseCsvRow,
+  type JournalSummaryData,
+  type JournalSummaryTransaction,
+} from "./choice-journal-summary-parser";
+
+export {
+  parseHotelStats,
+  getRevParValue,
+  REVPAR_HEADER_PREFIX,
+  type HotelStatsData,
+} from "./choice-hotel-stats-parser";
+
+export {
+  loadChoiceMapping,
+  parseChoiceMappingWorkbook,
+  findChoiceMappingEntry,
+  CHOICE_MAPPING_PREFIX,
+  CHOICE_NOT_MAPPED,
+  REVPAR_DATE_PLACEHOLDER,
+  type ChoiceMappingEntry,
+  type ChoiceMapping,
+} from "./choice-mapping-loader";
+
+export {
+  transformJournalSummaryToJERecords,
+  transformHotelStatsToStatJERecords,
+  parseStatAmount,
+  buildRevParHeader,
+} from "./choice-transformation";

--- a/src/config/property-config.ts
+++ b/src/config/property-config.ts
@@ -29,6 +29,12 @@ export interface PropertyConfig {
    * Not needed for Visual Matrix properties (extracted from PDF).
    */
   roomsAvailable?: number;
+  /**
+   * Property display name as it appears in the Choice Hotels mapping workbook
+   * (e.g. "Comfort Inn - Missoula").  Used to resolve property-specific GL
+   * accounts (cash-in-bank) from the mapping.  Only set for Choice properties.
+   */
+  choiceMappingName?: string;
 }
 
 /**
@@ -144,6 +150,44 @@ const PROPERTY_CONFIGURATIONS: PropertyConfig[] = [
     locationName: "Holiday Inn Express - Clover Lane",
     creditCardDepositAccount: "10030-531",
     roomsAvailable: 65,
+  },
+  // ── Choice Hotels properties ─────────────────────────────────────────────
+  // Sender: AUTO_MAIL_DELIVERY_SYSTEM@choicehotels.com (shared) → SSM sentinel __choice__
+  // Property code extracted from ZIP filename: All_Night_Audit_Reports_{CODE}_*.zip
+  // Cash-in-bank accounts are per-property and come from the Choice mapping workbook,
+  // so creditCardDepositAccount is unused for these properties.
+  {
+    // Choice Hotels — Comfort Inn Missoula, MT (property code MT118)
+    propertyName: "comfort-inn-missoula",
+    locationInternalId: "21",
+    subsidiaryInternalId: "37",
+    subsidiaryFullName:
+      "Parent Company : Warren Family Hotels : Warren Resort Hotels of Missoula, Inc.",
+    locationName: "Comfort Inn - Missoula",
+    creditCardDepositAccount: "", // Handled per-transaction by Choice mapping
+    choiceMappingName: "Comfort Inn - Missoula",
+  },
+  {
+    // Choice Hotels — Comfort Inn & Suites Ashland, OR (property code OR258)
+    propertyName: "comfort-inn-suites-ashland",
+    locationInternalId: "22",
+    subsidiaryInternalId: "28",
+    subsidiaryFullName:
+      "Parent Company : Warren Family Hotels : Warren Resort Hotels of Medford, Inc.",
+    locationName: "Comfort Inn & Suites - Ashland",
+    creditCardDepositAccount: "", // Handled per-transaction by Choice mapping
+    choiceMappingName: "Comfort Inn & Suites - Ashland",
+  },
+  {
+    // Choice Hotels — Comfort Inn & Suites Spokane Valley, WA (property code WA244)
+    propertyName: "comfort-inn-suites-spokane-valley",
+    locationInternalId: "23",
+    subsidiaryInternalId: "30",
+    subsidiaryFullName:
+      "Parent Company : Warren Family Hotels : Warren Resort Hotels of Spokane Valley, Inc.",
+    locationName: "Comfort Inn & Suites - Spokane Valley",
+    creditCardDepositAccount: "", // Handled per-transaction by Choice mapping
+    choiceMappingName: "Comfort Inn & Suites - Spokane Valley",
   },
 ];
 

--- a/src/config/property-config.ts
+++ b/src/config/property-config.ts
@@ -161,8 +161,7 @@ const PROPERTY_CONFIGURATIONS: PropertyConfig[] = [
     propertyName: "comfort-inn-missoula",
     locationInternalId: "21",
     subsidiaryInternalId: "37",
-    subsidiaryFullName:
-      "Parent Company : Warren Family Hotels : Warren Resort Hotels of Missoula, Inc.",
+    subsidiaryFullName: "Comfort Inn Missoula",
     locationName: "Comfort Inn - Missoula",
     creditCardDepositAccount: "", // Handled per-transaction by Choice mapping
     choiceMappingName: "Comfort Inn - Missoula",
@@ -172,8 +171,7 @@ const PROPERTY_CONFIGURATIONS: PropertyConfig[] = [
     propertyName: "comfort-inn-suites-ashland",
     locationInternalId: "22",
     subsidiaryInternalId: "28",
-    subsidiaryFullName:
-      "Parent Company : Warren Family Hotels : Warren Resort Hotels of Medford, Inc.",
+    subsidiaryFullName: "Comfort Inn & Suites Ashland",
     locationName: "Comfort Inn & Suites - Ashland",
     creditCardDepositAccount: "", // Handled per-transaction by Choice mapping
     choiceMappingName: "Comfort Inn & Suites - Ashland",
@@ -183,8 +181,7 @@ const PROPERTY_CONFIGURATIONS: PropertyConfig[] = [
     propertyName: "comfort-inn-suites-spokane-valley",
     locationInternalId: "23",
     subsidiaryInternalId: "30",
-    subsidiaryFullName:
-      "Parent Company : Warren Family Hotels : Warren Resort Hotels of Spokane Valley, Inc.",
+    subsidiaryFullName: "Comfort Inn & Suites Spokane Valley",
     locationName: "Comfort Inn & Suites - Spokane Valley",
     creditCardDepositAccount: "", // Handled per-transaction by Choice mapping
     choiceMappingName: "Comfort Inn & Suites - Spokane Valley",

--- a/src/email/report-email-sender.test.ts
+++ b/src/email/report-email-sender.test.ts
@@ -594,5 +594,81 @@ describe("ReportEmailSender", () => {
       // Should indicate these were skipped/already processed
       expect(rawEmail).toContain("Skipped");
     });
+
+    it("should render missingChoiceFiles section in both HTML and text parts", async () => {
+      const summaryWithMissingChoice: ReportSummary = {
+        ...mockSummary,
+        missingChoiceFiles: [
+          {
+            propertyName: "Comfort Inn - Missoula",
+            folderDate: "2026-06-14",
+            missingFileType: "hotel-statistics",
+          },
+          {
+            propertyName: "Comfort Inn & Suites - Ashland",
+            folderDate: "2026-06-14",
+            missingFileType: "journal-summary",
+          },
+        ],
+      };
+
+      const sender = new ReportEmailSender({
+        processedBucket: "test-processed-bucket",
+        region: "us-east-1",
+      });
+
+      const result = await sender.sendReportEmail(
+        "reports/2026-06-15/2026-06-14_JE.csv",
+        "reports/2026-06-15/2026-06-14_StatJE.csv",
+        summaryWithMissingChoice,
+        "test-correlation-id",
+      );
+
+      expect(result.success).toBe(true);
+
+      const sendCall = mockSESSend.mock.calls[0][0];
+      const rawEmail = sendCall.RawMessage.Data.toString();
+
+      // HTML and text should contain the missing Choice Hotels section
+      expect(rawEmail).toContain("Comfort Inn - Missoula");
+      expect(rawEmail).toContain("Comfort Inn &amp; Suites - Ashland");
+      expect(rawEmail).toContain("Hotel Statistics*.csv");
+      expect(rawEmail).toContain("Hotel Journal Summary*.csv");
+      expect(rawEmail).toContain("MISSING CHOICE HOTELS FILES");
+    });
+
+    it("should render missingOperaFiles with stat_dmy_seg type in both HTML and text parts", async () => {
+      const summaryWithMissingOpera: ReportSummary = {
+        ...mockSummary,
+        missingOperaFiles: [
+          {
+            propertyName: "Holiday Inn Express",
+            folderDate: "2026-06-14",
+            missingFileType: "stat",
+          },
+        ],
+      };
+
+      const sender = new ReportEmailSender({
+        processedBucket: "test-processed-bucket",
+        region: "us-east-1",
+      });
+
+      const result = await sender.sendReportEmail(
+        "reports/2026-06-15/2026-06-14_JE.csv",
+        "reports/2026-06-15/2026-06-14_StatJE.csv",
+        summaryWithMissingOpera,
+        "test-correlation-id",
+      );
+
+      expect(result.success).toBe(true);
+
+      const sendCall = mockSESSend.mock.calls[0][0];
+      const rawEmail = sendCall.RawMessage.Data.toString();
+
+      expect(rawEmail).toContain("Holiday Inn Express");
+      expect(rawEmail).toContain("stat_dmy_seg*.txt");
+      expect(rawEmail).toContain("MISSING OPERA FILES");
+    });
   });
 });

--- a/src/email/report-email-sender.ts
+++ b/src/email/report-email-sender.ts
@@ -19,6 +19,7 @@ import { RetryConfig } from "../types/errors";
 import type {
   SkippedDuplicate,
   MissingOperaFile,
+  MissingChoiceFile,
 } from "../lambda/file-processor";
 
 /**
@@ -66,6 +67,11 @@ export interface ReportSummary {
    * Each entry generates a red notice in the outbound email.
    */
   missingOperaFiles?: MissingOperaFile[];
+  /**
+   * Choice Hotels properties that received only one of the two expected daily files.
+   * Each entry generates a notice in the outbound email.
+   */
+  missingChoiceFiles?: MissingChoiceFile[];
 }
 
 /**
@@ -390,6 +396,8 @@ export class ReportEmailSender {
       summary.skippedDuplicates && summary.skippedDuplicates.length > 0;
     const hasMissingOperaFiles =
       summary.missingOperaFiles && summary.missingOperaFiles.length > 0;
+    const hasMissingChoiceFiles =
+      summary.missingChoiceFiles && summary.missingChoiceFiles.length > 0;
 
     // Use detailed view if propertyDetails available, otherwise simple list
     const propertiesSection = hasPropertyDetails
@@ -440,6 +448,26 @@ export class ReportEmailSender {
               .missingOperaFiles!.map(
                 (m) =>
                   `<li><strong>${this.escapeHtml(m.propertyName)}</strong> — missing <strong>${m.missingFileType === "trial_balance" ? "trial_balance*.txt" : "stat_dmy_seg*.txt"}</strong> (folder date: ${this.escapeHtml(m.folderDate)})</li>`,
+              )
+              .join("\n")}
+          </ul>
+        </div>
+      `
+      : "";
+
+    const missingChoiceSection = hasMissingChoiceFiles
+      ? `
+        <h3 style="color: #e67e22;">⚠ Missing Choice Hotels Files</h3>
+        <div style="background-color: #fffaf0; padding: 15px; border-radius: 4px; border-left: 4px solid #e67e22;">
+          <p style="margin: 0 0 10px 0; font-size: 13px; color: #e67e22; font-weight: bold;">
+            The following Choice Hotels files were NOT received and could not be included in today's report.
+            The hotel should be contacted to confirm delivery.
+          </p>
+          <ul style="margin: 0; color: #e67e22;">
+            ${summary
+              .missingChoiceFiles!.map(
+                (m) =>
+                  `<li><strong>${this.escapeHtml(m.propertyName)}</strong> — missing <strong>${m.missingFileType === "hotel-statistics" ? "Hotel Statistics*.csv" : "Hotel Journal Summary*.csv"}</strong> (folder date: ${this.escapeHtml(m.folderDate)})</li>`,
               )
               .join("\n")}
           </ul>
@@ -511,6 +539,8 @@ export class ReportEmailSender {
 
       ${missingOperaSection}
 
+      ${missingChoiceSection}
+
       ${errorSection}
 
       <h3>Attachments</h3>
@@ -540,6 +570,8 @@ export class ReportEmailSender {
       summary.skippedDuplicates && summary.skippedDuplicates.length > 0;
     const hasMissingOperaFilesText =
       summary.missingOperaFiles && summary.missingOperaFiles.length > 0;
+    const hasMissingChoiceFilesText =
+      summary.missingChoiceFiles && summary.missingChoiceFiles.length > 0;
 
     const propertyList = summary.propertyNames
       .map((name) => `  - ${name}`)
@@ -567,6 +599,15 @@ export class ReportEmailSender {
           .join("\n")}\n`
       : "";
 
+    const missingChoiceTextSection = hasMissingChoiceFilesText
+      ? `\n*** MISSING CHOICE HOTELS FILES ***\n${summary
+          .missingChoiceFiles!.map(
+            (m) =>
+              `  ! ${m.propertyName} — MISSING ${m.missingFileType === "hotel-statistics" ? "Hotel Statistics*.csv" : "Hotel Journal Summary*.csv"} (folder date: ${m.folderDate})`,
+          )
+          .join("\n")}\n`
+      : "";
+
     return `
 DAILY HOTEL REPORTS - ${dateFormatted}
 ${"=".repeat(50)}
@@ -583,7 +624,7 @@ Processing Time:     ${(summary.processingTimeMs / 1000).toFixed(2)} seconds
 PROPERTIES INCLUDED
 -------------------
 ${propertyList}
-${skippedSection}${missingOperaTextSection}${errorSection}
+${skippedSection}${missingOperaTextSection}${missingChoiceTextSection}${errorSection}
 ATTACHMENTS
 -----------
 - ${summary.reportDate}_JE.csv - Journal Entry file for NetSuite import

--- a/src/lambda/email-processor.test.ts
+++ b/src/lambda/email-processor.test.ts
@@ -25,6 +25,7 @@ const mockS3Client = {
 
 const mockParameterStore = {
   getPropertyMapping: vi.fn(),
+  getOverrideEmails: vi.fn(),
 };
 
 // Mock constructors
@@ -1088,6 +1089,117 @@ describe("EmailProcessor", () => {
         buildSesEvent("zip-nocode-test"),
       );
 
+      expect(result.processedAttachments[0]).toContain("unknown-property");
+    });
+
+    it("routes Choice ZIP to correct property when sender is on override list", async () => {
+      mockS3Client.send.mockResolvedValueOnce({
+        Body: {
+          transformToByteArray: () => Promise.resolve(Buffer.from("raw email")),
+        },
+      });
+
+      (simpleParser as Mock).mockResolvedValue({
+        from: {
+          value: [{ address: "johnhayesnielsen@gmail.com" }],
+          text: "johnhayesnielsen@gmail.com",
+        },
+        to: { text: "inbound@aws.example.com" },
+        subject: "Fwd: Night audit report WA244",
+        date: new Date("2026-06-26T12:00:00.000Z"),
+        attachments: [
+          {
+            filename: "All_Night_Audit_Reports_WA244_ACCOUNTING_2026-06-26.zip",
+            contentType: "application/zip",
+            content: Buffer.from("fake-zip-data"),
+            size: 100,
+          },
+        ],
+      });
+
+      (AdmZip as Mock).mockImplementation(function () {
+        return {
+          getEntries: vi.fn().mockReturnValue([
+            {
+              isDirectory: false,
+              entryName: "Hotel Statistics_2026-06-26.csv",
+              getData: vi.fn().mockReturnValue(Buffer.from("csv,data")),
+            },
+          ]),
+        };
+      });
+
+      // Sender not in property mapping → unknown-property
+      mockParameterStore.getPropertyMapping.mockResolvedValueOnce({});
+      // Override list includes the sender
+      mockParameterStore.getOverrideEmails.mockResolvedValueOnce([
+        "johnhayesnielsen@gmail.com",
+      ]);
+      // Second property-mapping lookup: choice:wa244 → correct slug
+      mockParameterStore.getPropertyMapping.mockResolvedValueOnce({
+        "choice:wa244": "comfort-inn-suites-spokane-valley",
+      });
+
+      mockS3Client.send.mockResolvedValue({});
+
+      const result = await emailProcessor.processEmail(
+        buildSesEvent("zip-override-choice-test"),
+      );
+
+      expect(result.statusCode).toBe(200);
+      expect(result.processedAttachments).toHaveLength(1);
+      expect(result.processedAttachments[0]).toContain(
+        "comfort-inn-suites-spokane-valley",
+      );
+    });
+
+    it("returns unknown-property for override sender when ZIP has no Choice pattern", async () => {
+      mockS3Client.send.mockResolvedValueOnce({
+        Body: {
+          transformToByteArray: () => Promise.resolve(Buffer.from("raw email")),
+        },
+      });
+
+      (simpleParser as Mock).mockResolvedValue({
+        from: {
+          value: [{ address: "johnhayesnielsen@gmail.com" }],
+        },
+        attachments: [
+          {
+            filename: "some_random_report.zip",
+            contentType: "application/zip",
+            content: Buffer.from("fake-zip-data"),
+            size: 100,
+          },
+        ],
+      });
+
+      (AdmZip as Mock).mockImplementation(function () {
+        return {
+          getEntries: vi.fn().mockReturnValue([
+            {
+              isDirectory: false,
+              entryName: "report.csv",
+              getData: vi.fn().mockReturnValue(Buffer.from("csv,data")),
+            },
+          ]),
+        };
+      });
+
+      // Sender not in property mapping
+      mockParameterStore.getPropertyMapping.mockResolvedValueOnce({});
+      // Override list includes the sender but ZIP doesn't match Choice pattern
+      mockParameterStore.getOverrideEmails.mockResolvedValueOnce([
+        "johnhayesnielsen@gmail.com",
+      ]);
+
+      mockS3Client.send.mockResolvedValue({});
+
+      const result = await emailProcessor.processEmail(
+        buildSesEvent("zip-override-nonChoice-test"),
+      );
+
+      expect(result.statusCode).toBe(200);
       expect(result.processedAttachments[0]).toContain("unknown-property");
     });
   });

--- a/src/lambda/email-processor.test.ts
+++ b/src/lambda/email-processor.test.ts
@@ -4,11 +4,13 @@ import { SESEvent, SESMail, Context } from "aws-lambda";
 import { S3Client } from "@aws-sdk/client-s3";
 import { simpleParser } from "mailparser";
 import { ParameterStoreConfig } from "../config/parameter-store";
+import AdmZip from "adm-zip";
 
 // Mock dependencies
 vi.mock("@aws-sdk/client-s3");
 vi.mock("mailparser");
 vi.mock("../config/parameter-store");
+vi.mock("adm-zip");
 vi.mock("../config/environment", () => ({
   environmentConfig: {
     environment: "test",
@@ -836,12 +838,257 @@ describe("EmailProcessor", () => {
       expect(isValid({ filename: "spreadsheet.xlsx" })).toBe(true);
       expect(isValid({ filename: "legacy.xls" })).toBe(true);
 
+      // ZIP is now valid — Choice Hotels reports arrive as ZIP attachments
+      expect(isValid({ filename: "archive.zip" })).toBe(true);
+
       expect(isValid({ filename: "image.jpg" })).toBe(false);
       expect(isValid({ filename: "video.mp4" })).toBe(false);
-      expect(isValid({ filename: "archive.zip" })).toBe(false);
       expect(isValid({ filename: "executable.exe" })).toBe(false);
       expect(isValid({ filename: null })).toBe(false);
       expect(isValid({})).toBe(false);
+    });
+  });
+
+  /**
+   * Test Group: ZIP attachment processing (Choice Hotels)
+   */
+  describe("ZIP attachment processing", () => {
+    const buildSesEvent = (messageId: string): SESEvent => ({
+      Records: [
+        {
+          eventSource: "aws:ses",
+          eventVersion: "1.0",
+          ses: {
+            mail: {
+              messageId,
+              timestamp: "2026-06-23T12:00:00.000Z",
+              source: "auto_mail_delivery_system@choicehotels.com",
+              destination: ["inbound@aws.example.com"],
+              commonHeaders: {
+                from: ["auto_mail_delivery_system@choicehotels.com"],
+                to: ["inbound@aws.example.com"],
+                subject: `Night audit report WA244 06/23/2026`,
+              },
+            } as SESMail,
+            receipt: {
+              recipients: ["inbound@aws.example.com"],
+              timestamp: "2026-06-23T12:00:00.000Z",
+              processingTimeMillis: 100,
+              ...defaultReceiptVerdicts,
+              action: {
+                type: "S3",
+                bucketName: "test-bucket",
+                objectKey: `raw-emails/${messageId}`,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    it("extracts CSV files from a ZIP attachment for a Choice Hotels property", async () => {
+      // Raw email retrieval
+      mockS3Client.send.mockResolvedValueOnce({
+        Body: {
+          transformToByteArray: () => Promise.resolve(Buffer.from("raw email")),
+        },
+      });
+
+      // simpleParser returns a ZIP attachment
+      (simpleParser as Mock).mockResolvedValue({
+        from: {
+          value: [{ address: "auto_mail_delivery_system@choicehotels.com" }],
+          text: "auto_mail_delivery_system@choicehotels.com",
+        },
+        to: { text: "inbound@aws.example.com" },
+        subject: "Night audit report WA244 06/23/2026",
+        date: new Date("2026-06-23T12:00:00.000Z"),
+        attachments: [
+          {
+            filename:
+              "All_Night_Audit_Reports_WA244_HOTEL STATS_2026-06-23.zip",
+            contentType: "application/zip",
+            content: Buffer.from("fake-zip-data"),
+            size: 100,
+          },
+        ],
+      });
+
+      // AdmZip returns one CSV entry
+      (AdmZip as Mock).mockImplementation(function () {
+        return {
+          getEntries: vi.fn().mockReturnValue([
+            {
+              isDirectory: false,
+              entryName: "Hotel Statistics_2026-06-23.csv",
+              getData: vi.fn().mockReturnValue(Buffer.from("csv,data")),
+            },
+          ]),
+        };
+      });
+
+      // First SSM lookup: sender email → __choice__
+      mockParameterStore.getPropertyMapping
+        .mockResolvedValueOnce({
+          "auto_mail_delivery_system@choicehotels.com": "__choice__",
+        })
+        // Second SSM lookup: choice:wa244 → property slug
+        .mockResolvedValueOnce({
+          "choice:wa244": "comfort-inn-suites-spokane-valley",
+        });
+
+      // S3 put for CSV entry + S3 put for metadata
+      mockS3Client.send.mockResolvedValue({});
+
+      const result = await emailProcessor.processEmail(
+        buildSesEvent("zip-choice-test"),
+      );
+
+      expect(result.statusCode).toBe(200);
+      expect(result.processedAttachments).toHaveLength(1);
+      expect(result.processedAttachments[0]).toContain(
+        "comfort-inn-suites-spokane-valley",
+      );
+    });
+
+    it("returns empty list when ZIP file is unreadable", async () => {
+      mockS3Client.send.mockResolvedValueOnce({
+        Body: {
+          transformToByteArray: () => Promise.resolve(Buffer.from("raw email")),
+        },
+      });
+
+      (simpleParser as Mock).mockResolvedValue({
+        from: {
+          value: [{ address: "auto_mail_delivery_system@choicehotels.com" }],
+        },
+        attachments: [
+          {
+            filename: "bad.zip",
+            contentType: "application/zip",
+            content: Buffer.from("not-a-zip"),
+            size: 10,
+          },
+        ],
+      });
+
+      // AdmZip throws on invalid content
+      (AdmZip as Mock).mockImplementation(function () {
+        throw new Error("Invalid ZIP file");
+      });
+
+      mockParameterStore.getPropertyMapping.mockResolvedValue({});
+      mockS3Client.send.mockResolvedValue({});
+
+      const result = await emailProcessor.processEmail(
+        buildSesEvent("zip-bad-test"),
+      );
+
+      expect(result.statusCode).toBe(200);
+      expect(result.processedAttachments).toHaveLength(0);
+    });
+
+    it("skips non-document entries inside a ZIP", async () => {
+      mockS3Client.send.mockResolvedValueOnce({
+        Body: {
+          transformToByteArray: () => Promise.resolve(Buffer.from("raw email")),
+        },
+      });
+
+      (simpleParser as Mock).mockResolvedValue({
+        from: {
+          value: [{ address: "auto_mail_delivery_system@choicehotels.com" }],
+        },
+        attachments: [
+          {
+            filename:
+              "All_Night_Audit_Reports_WA244_HOTEL STATS_2026-06-23.zip",
+            contentType: "application/zip",
+            content: Buffer.from("zip"),
+            size: 100,
+          },
+        ],
+      });
+
+      (AdmZip as Mock).mockImplementation(function () {
+        return {
+          getEntries: vi.fn().mockReturnValue([
+            {
+              isDirectory: false,
+              entryName: "__MACOSX/image.jpg",
+              getData: vi.fn().mockReturnValue(Buffer.from("img")),
+            },
+            {
+              isDirectory: true,
+              entryName: "subfolder/",
+              getData: vi.fn(),
+            },
+          ]),
+        };
+      });
+
+      mockParameterStore.getPropertyMapping
+        .mockResolvedValueOnce({
+          "auto_mail_delivery_system@choicehotels.com": "__choice__",
+        })
+        .mockResolvedValueOnce({
+          "choice:wa244": "comfort-inn-suites-spokane-valley",
+        });
+
+      mockS3Client.send.mockResolvedValue({});
+
+      const result = await emailProcessor.processEmail(
+        buildSesEvent("zip-skip-test"),
+      );
+
+      expect(result.processedAttachments).toHaveLength(0);
+    });
+
+    it("falls back to unknown-property when ZIP filename has no property code", async () => {
+      mockS3Client.send.mockResolvedValueOnce({
+        Body: {
+          transformToByteArray: () => Promise.resolve(Buffer.from("raw email")),
+        },
+      });
+
+      (simpleParser as Mock).mockResolvedValue({
+        from: {
+          value: [{ address: "auto_mail_delivery_system@choicehotels.com" }],
+        },
+        attachments: [
+          {
+            filename: "unrecognised_name.zip",
+            contentType: "application/zip",
+            content: Buffer.from("zip"),
+            size: 100,
+          },
+        ],
+      });
+
+      (AdmZip as Mock).mockImplementation(function () {
+        return {
+          getEntries: vi.fn().mockReturnValue([
+            {
+              isDirectory: false,
+              entryName: "Hotel Statistics_2026-06-23.csv",
+              getData: vi.fn().mockReturnValue(Buffer.from("csv")),
+            },
+          ]),
+        };
+      });
+
+      // Sender maps to __choice__ but no property code in filename
+      mockParameterStore.getPropertyMapping.mockResolvedValueOnce({
+        "auto_mail_delivery_system@choicehotels.com": "__choice__",
+      });
+
+      mockS3Client.send.mockResolvedValue({});
+
+      const result = await emailProcessor.processEmail(
+        buildSesEvent("zip-nocode-test"),
+      );
+
+      expect(result.processedAttachments[0]).toContain("unknown-property");
     });
   });
 });

--- a/src/lambda/email-processor.ts
+++ b/src/lambda/email-processor.ts
@@ -802,8 +802,29 @@ export class EmailProcessor {
     );
 
     if (slugFromSender !== CHOICE_SENTINEL) {
-      // Non-Choice ZIP: use the sender-resolved slug as-is
-      return slugFromSender;
+      // If this is an override sender forwarding a Choice Hotels ZIP, bypass the
+      // sentinel requirement and route by filename instead so that trusted senders
+      // can forward Choice emails without needing __choice__ in their own mapping.
+      const overrideEmails = await retryParameterStoreOperation(
+        () => this.parameterStore.getOverrideEmails(),
+        correlationId,
+        "get_override_emails_for_zip",
+      );
+      const isOverrideSender = overrideEmails.includes(
+        senderEmail.toLowerCase(),
+      );
+      const choiceMatch = zipFilename.match(CHOICE_ZIP_CODE_PATTERN);
+
+      if (!(isOverrideSender && choiceMatch)) {
+        // Non-Choice ZIP or non-override sender: use the sender-resolved slug as-is
+        return slugFromSender;
+      }
+
+      logger.debug(
+        "Override sender forwarding Choice ZIP — using filename routing",
+        { senderEmail, zipFilename },
+      );
+      // Fall through to Choice filename routing below
     }
 
     // Choice Hotels ZIP: extract property code from filename and do a second lookup

--- a/src/lambda/email-processor.ts
+++ b/src/lambda/email-processor.ts
@@ -4,6 +4,7 @@ import {
   PutObjectCommand,
 } from "@aws-sdk/client-s3";
 import { randomUUID } from "crypto";
+import AdmZip from "adm-zip";
 import { SESEvent, SESMail, Context } from "aws-lambda";
 import { simpleParser, ParsedMail, Attachment } from "mailparser";
 import { ParameterStoreConfig } from "../config/parameter-store";
@@ -19,6 +20,19 @@ import {
 } from "../types/errors";
 import { createCorrelatedLogger } from "../utils/logger";
 import { retryS3Operation, retryParameterStoreOperation } from "../utils/retry";
+
+/**
+ * SSM email-mapping sentinel value for the shared Choice Hotels sender address.
+ * When this value is returned from the property mapping, the property slug is
+ * derived from the property code embedded in the ZIP attachment filename instead.
+ */
+const CHOICE_SENTINEL = "__choice__";
+
+/**
+ * Pattern to extract the Choice Hotels property code from a ZIP filename.
+ * Example: "All_Night_Audit_Reports_WA244_HOTEL STATS_2026-06-23.zip" → "WA244"
+ */
+const CHOICE_ZIP_CODE_PATTERN = /All_Night_Audit_Reports_([A-Z]{2}\d{3})_/i;
 
 /**
  * EmailProcessor handles incoming emails from Amazon SES, extracts attachments,
@@ -370,18 +384,37 @@ export class EmailProcessor {
           continue;
         }
 
-        const storedPath = await this.storeAttachment(
-          attachment,
-          parsedEmail,
-          sesMessage,
-          correlationId,
-        );
-        storedAttachments.push(storedPath);
+        const filename = attachment.filename?.toLowerCase() ?? "";
+        if (filename.endsWith(".zip")) {
+          // Extract ZIP contents and store each valid file individually.
+          // The property slug is derived from the ZIP filename for Choice Hotels.
+          const extractedPaths = await this.processZipAttachment(
+            attachment,
+            parsedEmail,
+            sesMessage,
+            correlationId,
+          );
+          storedAttachments.push(...extractedPaths);
 
-        attachmentLogger.info("Attachment processed successfully", {
-          storedPath,
-          size: attachment.size,
-        });
+          attachmentLogger.info("ZIP attachment extracted and stored", {
+            zipFilename: attachment.filename,
+            extractedCount: extractedPaths.length,
+            storedPaths: extractedPaths,
+          });
+        } else {
+          const storedPath = await this.storeAttachment(
+            attachment,
+            parsedEmail,
+            sesMessage,
+            correlationId,
+          );
+          storedAttachments.push(storedPath);
+
+          attachmentLogger.info("Attachment processed successfully", {
+            storedPath,
+            size: attachment.size,
+          });
+        }
       } catch (error) {
         attachmentLogger.error("Failed to process attachment", error as Error, {
           filename: attachment.filename,
@@ -389,8 +422,8 @@ export class EmailProcessor {
           size: attachment.size,
         });
 
-        // For attachment processing, we log the error but continue with other attachments
-        // This prevents one bad attachment from failing the entire email processing
+        // Log the error but continue with other attachments —
+        // one bad attachment must not fail the entire email processing.
         continue;
       }
     }
@@ -415,7 +448,7 @@ export class EmailProcessor {
   private isValidAttachment(attachment: Attachment): boolean {
     if (!attachment.filename) return false;
 
-    const validExtensions = [".pdf", ".csv", ".txt", ".xlsx", ".xls"];
+    const validExtensions = [".pdf", ".csv", ".txt", ".xlsx", ".xls", ".zip"];
     const filename = attachment.filename.toLowerCase();
 
     return validExtensions.some((ext) => filename.endsWith(ext));
@@ -621,6 +654,193 @@ export class EmailProcessor {
     const name = filename.substring(0, lastDotIndex);
     const extension = filename.substring(lastDotIndex);
     return `${name}_${uniqueId}${extension}`;
+  }
+
+  /**
+   * Extracts files from a ZIP attachment and stores each valid file in S3.
+   *
+   * For Choice Hotels ZIPs, the property slug is resolved from the ZIP filename
+   * using the embedded property code (e.g. "WA244" → comfort-inn-suites-spokane-valley).
+   * Each extracted CSV is stored under the resolved slug, just like a regular attachment.
+   *
+   * @param attachment - The ZIP attachment
+   * @param parsedEmail - Parsed email containing sender metadata
+   * @param sesMessage - SES message metadata
+   * @param correlationId - Correlation ID for tracking
+   * @returns Array of S3 keys for all stored files
+   *
+   * @private
+   */
+  private async processZipAttachment(
+    attachment: Attachment,
+    parsedEmail: ParsedMail,
+    sesMessage: SESMail,
+    correlationId: string,
+  ): Promise<string[]> {
+    const logger = createCorrelatedLogger(correlationId, {
+      messageId: sesMessage.messageId,
+      zipFilename: attachment.filename,
+      operation: "process_zip_attachment",
+    });
+
+    const storedPaths: string[] = [];
+
+    let zip: AdmZip;
+    try {
+      zip = new AdmZip(attachment.content);
+    } catch (error) {
+      logger.error("Failed to open ZIP attachment", error as Error, {
+        zipFilename: attachment.filename,
+      });
+      return storedPaths;
+    }
+
+    const entries = zip.getEntries();
+    logger.info("Extracted ZIP entries", {
+      zipFilename: attachment.filename,
+      entryCount: entries.length,
+    });
+
+    // Determine the property slug for this ZIP using the Choice property-code
+    // pattern.  Falls back to the sender email lookup so non-Choice ZIPs (if any
+    // ever arrive) are routed normally.
+    const senderEmail =
+      parsedEmail.from?.value?.[0]?.address ||
+      parsedEmail.from?.text ||
+      "unknown-sender";
+
+    const zipFilename = attachment.filename ?? "";
+    const propertySlug = await this.resolvePropertySlugForZip(
+      zipFilename,
+      senderEmail,
+      correlationId,
+    );
+
+    const validExtensions = [".pdf", ".csv", ".txt", ".xlsx", ".xls"];
+
+    for (const entry of entries) {
+      if (entry.isDirectory) continue;
+
+      const entryName = entry.entryName.split("/").pop() ?? entry.entryName;
+      const entryLower = entryName.toLowerCase();
+
+      if (!validExtensions.some((ext) => entryLower.endsWith(ext))) {
+        logger.debug("Skipping non-document ZIP entry", { entryName });
+        continue;
+      }
+
+      try {
+        const content = entry.getData();
+        const sanitized = this.sanitizeFilename(entryName);
+        const uniqueFilename = this.addUniqueIdentifier(sanitized);
+        const s3Key = `daily-files/${propertySlug}/${new Date().toISOString().split("T")[0]}/${uniqueFilename}`;
+
+        const putCommand = new PutObjectCommand({
+          Bucket: this.incomingBucket,
+          Key: s3Key,
+          Body: content,
+          ContentType: "text/csv",
+          Metadata: {
+            originalFilename: entryName,
+            senderEmail,
+            messageId: sesMessage.messageId,
+            receivedDate: new Date().toISOString(),
+            propertyId: propertySlug,
+            sourceZip: zipFilename,
+          },
+        });
+
+        await retryS3Operation(
+          () => this.s3Client.send(putCommand),
+          correlationId,
+          "put_zip_entry_to_s3",
+        );
+
+        storedPaths.push(s3Key);
+        logger.debug("ZIP entry stored", { entryName, s3Key, propertySlug });
+      } catch (error) {
+        logger.error("Failed to store ZIP entry", error as Error, {
+          entryName,
+          propertySlug,
+        });
+      }
+    }
+
+    return storedPaths;
+  }
+
+  /**
+   * Resolve the property slug for a ZIP attachment.
+   *
+   * For Choice Hotels ZIPs:
+   *   1. Extract the property code from the ZIP filename (e.g. "WA244")
+   *   2. Look it up in SSM using the key "choice:{code}" (lowercase)
+   *
+   * For other ZIPs, fall back to the sender-email lookup.
+   *
+   * @param zipFilename - Original attachment filename
+   * @param senderEmail - Normalised sender email address
+   * @param correlationId - Correlation ID for logging
+   * @returns Resolved property slug, or "unknown-property" on failure
+   *
+   * @private
+   */
+  private async resolvePropertySlugForZip(
+    zipFilename: string,
+    senderEmail: string,
+    correlationId: string,
+  ): Promise<string> {
+    const logger = createCorrelatedLogger(correlationId, {
+      zipFilename,
+      operation: "resolve_property_slug_for_zip",
+    });
+
+    // First, look up the sender email to check if it maps to the Choice sentinel
+    const slugFromSender = await this.getPropertyIdFromSender(
+      senderEmail,
+      correlationId,
+    );
+
+    if (slugFromSender !== CHOICE_SENTINEL) {
+      // Non-Choice ZIP: use the sender-resolved slug as-is
+      return slugFromSender;
+    }
+
+    // Choice Hotels ZIP: extract property code from filename and do a second lookup
+    const codeMatch = zipFilename.match(CHOICE_ZIP_CODE_PATTERN);
+    if (!codeMatch) {
+      logger.warn(
+        "Choice Hotels ZIP filename does not match expected pattern — using unknown-property",
+        { zipFilename },
+      );
+      return "unknown-property";
+    }
+
+    const propertyCode = codeMatch[1].toUpperCase();
+    const lookupKey = `choice:${propertyCode.toLowerCase()}`;
+    logger.debug("Resolving Choice property code via SSM", {
+      propertyCode,
+      lookupKey,
+    });
+
+    const resolvedSlug = await this.getPropertyIdFromSender(
+      lookupKey,
+      correlationId,
+    );
+
+    if (!resolvedSlug || resolvedSlug === "unknown-property") {
+      logger.warn("No SSM mapping found for Choice property code", {
+        propertyCode,
+        lookupKey,
+      });
+      return "unknown-property";
+    }
+
+    logger.debug("Choice property code resolved", {
+      propertyCode,
+      resolvedSlug,
+    });
+    return resolvedSlug;
   }
 
   /**

--- a/src/lambda/file-processor.test.ts
+++ b/src/lambda/file-processor.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
-import { handler, FileProcessingEvent, FileProcessor } from "./file-processor";
+import {
+  handler,
+  FileProcessingEvent,
+  FileProcessor,
+  getOperaFileType,
+  getChoiceFileType,
+} from "./file-processor";
 import { EventBridgeEvent, Context } from "aws-lambda";
 import { S3Client } from "@aws-sdk/client-s3";
 import { ParameterStoreConfig } from "../config/parameter-store";
@@ -3035,5 +3041,73 @@ Room Revenue: 500.00`;
         "holiday-inn-express-clover-lane",
       );
     });
+  });
+});
+
+// ─── getOperaFileType ─────────────────────────────────────────────────────────
+
+describe("getOperaFileType", () => {
+  it("detects trial_balance file", () => {
+    expect(getOperaFileType("trial_balance_2026-06-14.txt")).toBe(
+      "trial_balance",
+    );
+  });
+
+  it("detects stat_dmy_seg file", () => {
+    expect(getOperaFileType("stat_dmy_seg_2026-06-14.txt")).toBe(
+      "stat_dmy_seg",
+    );
+  });
+
+  it("returns null for unrecognised filename", () => {
+    expect(getOperaFileType("report.pdf")).toBeNull();
+  });
+
+  it("handles full S3 key by using only the final segment", () => {
+    expect(
+      getOperaFileType(
+        "daily-files/holiday-inn/2026-06-14/trial_balance_abc.txt",
+      ),
+    ).toBe("trial_balance");
+  });
+
+  it("is case-insensitive", () => {
+    expect(getOperaFileType("Trial_Balance_2026-06-14.TXT")).toBe(
+      "trial_balance",
+    );
+  });
+});
+
+// ─── getChoiceFileType ────────────────────────────────────────────────────────
+
+describe("getChoiceFileType", () => {
+  it("detects hotel-statistics file", () => {
+    expect(getChoiceFileType("Hotel Statistics_2026-06-14.csv")).toBe(
+      "hotel-statistics",
+    );
+  });
+
+  it("detects journal-summary file", () => {
+    expect(getChoiceFileType("Hotel Journal Summary_2026-06-14.csv")).toBe(
+      "journal-summary",
+    );
+  });
+
+  it("returns null for unrecognised filename", () => {
+    expect(getChoiceFileType("report.pdf")).toBeNull();
+  });
+
+  it("handles full S3 key by using only the final segment", () => {
+    expect(
+      getChoiceFileType(
+        "daily-files/comfort-inn-missoula/2026-06-14/Hotel Statistics_2026-06-14.csv",
+      ),
+    ).toBe("hotel-statistics");
+  });
+
+  it("is case-insensitive", () => {
+    expect(getChoiceFileType("HOTEL STATISTICS_2026-06-14.CSV")).toBe(
+      "hotel-statistics",
+    );
   });
 });

--- a/src/lambda/file-processor.test.ts
+++ b/src/lambda/file-processor.test.ts
@@ -3110,4 +3110,20 @@ describe("getChoiceFileType", () => {
       "hotel-statistics",
     );
   });
+
+  // These sanitized (underscore) forms are what email-processor's
+  // sanitizeFilename() actually produces in S3 — this is the real-world
+  // filename shape, and the regression that caused Choice reports to be
+  // silently skipped in production.
+  it("detects hotel-statistics file with sanitized (underscore) separators", () => {
+    expect(getChoiceFileType("Hotel_Statistics_2026-07-07_550e7ef0.csv")).toBe(
+      "hotel-statistics",
+    );
+  });
+
+  it("detects journal-summary file with sanitized (underscore) separators", () => {
+    expect(
+      getChoiceFileType("Hotel_Journal_Summary_2026-07-07_1a348d85.csv"),
+    ).toBe("journal-summary");
+  });
 });

--- a/src/lambda/file-processor.ts
+++ b/src/lambda/file-processor.ts
@@ -2799,8 +2799,9 @@ export class FileProcessor {
       const mappingFiles = (listResult.Contents || [])
         .filter(
           (obj) =>
-            // Exclude Opera mapping files (under opera/ prefix)
+            // Exclude Opera and Choice mapping files (under their respective prefixes)
             !obj.Key?.startsWith("opera/") &&
+            !obj.Key?.startsWith("choice/") &&
             (obj.Key?.toLowerCase().endsWith(".xlsx") ||
               obj.Key?.toLowerCase().endsWith(".xls") ||
               obj.Key?.toLowerCase().endsWith(".csv")), // Also support CSV files that are actually Excel

--- a/src/lambda/file-processor.ts
+++ b/src/lambda/file-processor.ts
@@ -60,6 +60,14 @@ import {
   transformStatDmySegToStatJERecords,
   type OperaMapping,
 } from "../opera";
+import {
+  loadChoiceMapping,
+  parseJournalSummary,
+  parseHotelStats,
+  transformJournalSummaryToJERecords,
+  transformHotelStatsToStatJERecords,
+  type ChoiceMapping,
+} from "../choice";
 
 /**
  * Interface for the file processing event
@@ -144,6 +152,18 @@ export interface MissingOperaFile {
 }
 
 /**
+ * A Choice Hotels property that is missing one of its required paired files.
+ * Surfaced as a notice in the outbound email.
+ */
+export interface MissingChoiceFile {
+  propertyName: string;
+  /** S3 folder date (YYYY-MM-DD) used as proxy when business date is unavailable */
+  folderDate: string;
+  /** Which file type was not received */
+  missingFileType: "hotel-statistics" | "journal-summary";
+}
+
+/**
  * Interface for the file processing result
  */
 interface FileProcessingResult {
@@ -158,6 +178,7 @@ interface FileProcessingResult {
     reportsGenerated: number;
     skippedDuplicates: SkippedDuplicate[];
     missingOperaFiles: MissingOperaFile[];
+    missingChoiceFiles: MissingChoiceFile[];
   };
 }
 
@@ -324,6 +345,12 @@ export class FileProcessor {
         correlationId,
       );
 
+      // Load Choice mapping if any Choice Hotels files are present in the batch
+      const choiceMapping = await this.loadChoiceMappingIfNeeded(
+        organizedFiles,
+        correlationId,
+      );
+
       // Step 3: Process each property's files (Phase 3B)
       const processedFiles = await this.processPropertyFiles(
         organizedFiles,
@@ -337,17 +364,20 @@ export class FileProcessor {
       });
 
       // Step 4: Apply account code mappings (Phase 3C) with duplicate detection (Phase 6)
-      // Routes Opera files to the Opera path; all others use the VisualMatrix path.
+      // Routes Opera files to the Opera path, Choice files to the Choice path,
+      // all others to the VisualMatrix path.
       const {
         reports: transformedData,
         skippedDuplicates,
         missingOperaFiles,
+        missingChoiceFiles,
       } = await this.applyAccountCodeMappings(
         processedFiles,
         organizedFiles,
         correlationId,
         visualMatrixData,
         operaMapping,
+        choiceMapping,
       );
 
       logger.info("Data transformations applied", {
@@ -461,6 +491,7 @@ export class FileProcessor {
             propertyDetails,
             skippedDuplicates,
             missingOperaFiles,
+            missingChoiceFiles,
           };
 
           const emailResult = await this.emailSender.sendReportEmail(
@@ -497,6 +528,7 @@ export class FileProcessor {
           reportsGenerated: reportKeys.length,
           skippedDuplicates,
           missingOperaFiles,
+          missingChoiceFiles,
         },
       };
     } catch (error) {
@@ -517,6 +549,7 @@ export class FileProcessor {
           reportsGenerated: 0,
           skippedDuplicates: [],
           missingOperaFiles: [],
+          missingChoiceFiles: [],
         },
       };
     }
@@ -951,8 +984,8 @@ export class FileProcessor {
         businessDate = yesterday.toISOString().split("T")[0];
       }
 
-      // For Opera files, include the file type in the key so trial_balance and
-      // stat_dmy_seg files for the same property/date are not treated as duplicates
+      // For Opera and Choice files, include the file type in the key so the two
+      // paired files for the same property/date are not treated as duplicates
       // of each other — they are a required pair, not copies of the same report.
       const fileName = file.fileKey.split("/").pop() ?? "";
       const operaFileType = fileName.startsWith("trial_balance")
@@ -960,9 +993,12 @@ export class FileProcessor {
         : fileName.startsWith("stat_dmy_seg")
           ? "stat_dmy_seg"
           : null;
+      const choiceType = getChoiceFileType(fileName);
       const deduplicationKey = operaFileType
         ? `${propertyName}|${businessDate}|${operaFileType}`
-        : `${propertyName}|${businessDate}`;
+        : choiceType
+          ? `${propertyName}|${businessDate}|${choiceType}`
+          : `${propertyName}|${businessDate}`;
 
       identities.push({
         file,
@@ -1091,6 +1127,21 @@ export class FileProcessor {
               file.key,
               correlationId,
             );
+
+            // Choice Hotels CSV files must be stored as raw text so the Choice
+            // parsers receive the original CSV content.  Bypass the CSV parser
+            // to avoid having the content JSON-stringified into CSVParsedData.
+            if (getChoiceFileType(file.filename) !== null) {
+              processedFiles.push({
+                fileKey: file.key,
+                originalContent: fileContent.toString("utf-8"),
+                transformedData: [],
+                errors: [],
+                propertyId,
+                processingTime: Date.now() - startTime,
+              });
+              continue;
+            }
 
             // Determine file type and get appropriate parser
             const fileExtension = this.getFileExtension(file.filename);
@@ -1245,10 +1296,12 @@ export class FileProcessor {
     correlationId: string,
     visualMatrixData?: VisualMatrixData | null,
     operaMapping?: OperaMapping | null,
+    choiceMapping?: ChoiceMapping | null,
   ): Promise<{
     reports: ConsolidatedReport[];
     skippedDuplicates: SkippedDuplicate[];
     missingOperaFiles: MissingOperaFile[];
+    missingChoiceFiles: MissingChoiceFile[];
   }> {
     const logger = createCorrelatedLogger(correlationId, {
       operation: "apply_account_code_mappings",
@@ -1263,7 +1316,12 @@ export class FileProcessor {
       logger.error(
         "No VisualMatrix mapping data available - cannot process files",
       );
-      return { reports: [], skippedDuplicates: [], missingOperaFiles: [] };
+      return {
+        reports: [],
+        skippedDuplicates: [],
+        missingOperaFiles: [],
+        missingChoiceFiles: [],
+      };
     }
 
     // Load override emails once for the entire batch (cached by Parameter Store)
@@ -1287,6 +1345,7 @@ export class FileProcessor {
     const reportsByProperty: { [propertyId: string]: ConsolidatedReport } = {};
     const skippedDuplicates: SkippedDuplicate[] = [];
     const missingOperaFiles: MissingOperaFile[] = [];
+    const missingChoiceFiles: MissingChoiceFile[] = [];
 
     // --- Opera file processing ---
     // Group Opera files by property+date and process pairs before the VM loop.
@@ -1301,9 +1360,23 @@ export class FileProcessor {
       correlationId,
     );
 
-    // Exclude Opera files from the VM loop below
+    // --- Choice Hotels file processing ---
+    await this.processChoiceFilePairs(
+      deduplicatedFiles,
+      organizedFiles,
+      choiceMapping ?? null,
+      overrideEmails,
+      reportsByProperty,
+      skippedDuplicates,
+      missingChoiceFiles,
+      correlationId,
+    );
+
+    // Exclude Opera and Choice files from the VM loop below
     const vmFiles = deduplicatedFiles.filter(
-      (f) => getOperaFileType(f.fileKey) === null,
+      (f) =>
+        getOperaFileType(f.fileKey) === null &&
+        getChoiceFileType(f.fileKey) === null,
     );
 
     for (const file of vmFiles) {
@@ -1501,6 +1574,7 @@ export class FileProcessor {
       reports: Object.values(reportsByProperty),
       skippedDuplicates,
       missingOperaFiles,
+      missingChoiceFiles,
     };
   }
 
@@ -2478,6 +2552,227 @@ export class FileProcessor {
   }
 
   /**
+   * Load the Choice mapping from S3 only when at least one Choice Hotels file is
+   * present in the current batch (avoids an unnecessary S3 call on non-Choice batches).
+   */
+  private async loadChoiceMappingIfNeeded(
+    organizedFiles: OrganizedFiles,
+    correlationId: string,
+  ): Promise<ChoiceMapping | null> {
+    const hasChoiceFiles = Object.values(organizedFiles).some((dateMap) =>
+      Object.values(dateMap).some((files) =>
+        files.some((f) => getChoiceFileType(f.filename) !== null),
+      ),
+    );
+
+    if (!hasChoiceFiles) return null;
+
+    return loadChoiceMapping(this.s3Client, this.mappingBucket, correlationId);
+  }
+
+  /**
+   * Process Choice Hotels journal-summary / hotel-statistics file pairs.
+   *
+   * For each property+date with Choice files:
+   *   - Both present → full JE + StatJE output
+   *   - Only hotel-statistics → StatJE only, missing-file notice for journal-summary
+   *   - Only journal-summary → JE only, missing-file notice for hotel-statistics
+   *
+   * Results are merged directly into `reportsByProperty`.
+   */
+  private async processChoiceFilePairs(
+    processedFiles: ProcessedFileData[],
+    organizedFiles: OrganizedFiles,
+    choiceMapping: ChoiceMapping | null,
+    overrideEmails: string[],
+    reportsByProperty: { [key: string]: ConsolidatedReport },
+    skippedDuplicates: SkippedDuplicate[],
+    missingChoiceFiles: MissingChoiceFile[],
+    correlationId: string,
+  ): Promise<void> {
+    const logger = createCorrelatedLogger(correlationId, {
+      operation: "process_choice_file_pairs",
+    });
+
+    const fileByKey = new Map<string, ProcessedFileData>(
+      processedFiles.map((f) => [f.fileKey, f]),
+    );
+
+    for (const [propertyId, dateMap] of Object.entries(organizedFiles)) {
+      for (const [folderDate, s3Files] of Object.entries(dateMap)) {
+        const statsS3 = s3Files.find(
+          (f) => getChoiceFileType(f.filename) === "hotel-statistics",
+        );
+        const journalS3 = s3Files.find(
+          (f) => getChoiceFileType(f.filename) === "journal-summary",
+        );
+
+        if (!statsS3 && !journalS3) continue; // no Choice files this day
+
+        const statsFile = statsS3 ? fileByKey.get(statsS3.key) : undefined;
+        const journalFile = journalS3
+          ? fileByKey.get(journalS3.key)
+          : undefined;
+
+        // Track missing files
+        if (!statsS3) {
+          missingChoiceFiles.push({
+            propertyName: propertyId,
+            folderDate,
+            missingFileType: "hotel-statistics",
+          });
+        }
+        if (!journalS3) {
+          missingChoiceFiles.push({
+            propertyName: propertyId,
+            folderDate,
+            missingFileType: "journal-summary",
+          });
+        }
+
+        // Need the Hotel Statistics file to determine the business date
+        if (!statsFile || statsFile.errors.length > 0) {
+          logger.warn(
+            "Choice Hotel Statistics file missing or failed — skipping StatJE generation",
+            { propertyId, folderDate },
+          );
+          continue;
+        }
+
+        // Parse Hotel Statistics to get business date
+        let statsData;
+        try {
+          const rawStats = this.extractRawText(statsFile.originalContent);
+          statsData = parseHotelStats(rawStats);
+          logger.debug("Choice Hotel Statistics parsed", {
+            fileKey: statsFile.fileKey,
+            businessDate: statsData.businessDate,
+          });
+        } catch (err) {
+          logger.error(
+            "Failed to parse Choice Hotel Statistics",
+            err as Error,
+            {
+              fileKey: statsFile.fileKey,
+            },
+          );
+          continue;
+        }
+
+        const businessDate = statsData.businessDate;
+        const reportKey = `${propertyId}|${businessDate}`;
+
+        // Duplicate detection
+        const duplicateCheck = await this.duplicateDetector.checkIfProcessed(
+          propertyId,
+          businessDate,
+          correlationId,
+        );
+
+        if (duplicateCheck.isAlreadyProcessed) {
+          const senderEmail = await this.getSenderEmailFromMetadata(
+            statsFile.fileKey,
+            correlationId,
+          );
+          const isOverride =
+            overrideEmails.length > 0 &&
+            senderEmail !== null &&
+            overrideEmails.includes(senderEmail.toLowerCase());
+
+          if (!isOverride) {
+            skippedDuplicates.push({
+              propertyName: propertyId,
+              businessDate,
+              fileKey: statsFile.fileKey,
+              reason: "already_processed",
+            });
+            continue;
+          }
+        }
+
+        const propertyConfigService = getPropertyConfigService();
+        const propertyConfig =
+          propertyConfigService.getPropertyConfigOrDefault(propertyId);
+        const mappingPropertyName = propertyConfig.choiceMappingName ?? "";
+
+        // Build StatJE records from Hotel Statistics
+        const statJERecords = choiceMapping
+          ? transformHotelStatsToStatJERecords(statsData, choiceMapping)
+          : [];
+
+        // Build JE records from Journal Summary (if available)
+        const jeRecords: ReturnType<typeof transformJournalSummaryToJERecords> =
+          [];
+        if (journalFile && journalFile.errors.length === 0) {
+          try {
+            const rawJournal = this.extractRawText(journalFile.originalContent);
+            const journalData = parseJournalSummary(rawJournal);
+            logger.debug("Choice Journal Summary parsed", {
+              fileKey: journalFile.fileKey,
+              transactionCount: journalData.transactions.length,
+            });
+            if (choiceMapping) {
+              jeRecords.push(
+                ...transformJournalSummaryToJERecords(
+                  journalData,
+                  choiceMapping,
+                  mappingPropertyName,
+                ),
+              );
+            }
+          } catch (err) {
+            logger.error(
+              "Failed to parse Choice Journal Summary",
+              err as Error,
+              {
+                fileKey: journalFile.fileKey,
+              },
+            );
+          }
+        }
+
+        const allRecords = [
+          ...jeRecords.map((r) => ({ ...r, propertyId })),
+          ...statJERecords.map((r) => ({ ...r, propertyId })),
+        ];
+
+        if (allRecords.length > 0) {
+          if (!reportsByProperty[reportKey]) {
+            reportsByProperty[reportKey] = {
+              propertyId,
+              propertyName: propertyConfig.propertyName,
+              reportDate: businessDate,
+              totalFiles: 0,
+              totalRecords: 0,
+              data: [],
+              summary: {
+                processingTime: 0,
+                errors: [],
+                successfulFiles: 0,
+                failedFiles: 0,
+              },
+            };
+          }
+
+          const report = reportsByProperty[reportKey];
+          report.totalFiles += (statsFile ? 1 : 0) + (journalFile ? 1 : 0);
+          report.totalRecords += allRecords.length;
+          report.data.push(...allRecords);
+          report.summary.successfulFiles +=
+            (statsFile ? 1 : 0) + (journalFile ? 1 : 0);
+
+          logger.info("Choice Hotels file pair processed", {
+            propertyId,
+            businessDate,
+            jeRecords: jeRecords.length,
+            statJERecords: statJERecords.length,
+          });
+        }
+      }
+    }
+  }
+
+  /**
    * Helper method to load VisualMatrix mapping configuration
    */
   private async loadVisualMatrixMapping(
@@ -2776,6 +3071,7 @@ export class FileProcessor {
             skippedDuplicates: [],
 
             missingOperaFiles: [],
+            missingChoiceFiles: [],
           },
         };
       }
@@ -2821,6 +3117,7 @@ export class FileProcessor {
           skippedDuplicates: [],
 
           missingOperaFiles: [],
+          missingChoiceFiles: [],
         },
       };
     } catch (error) {
@@ -2842,6 +3139,7 @@ export class FileProcessor {
           skippedDuplicates: [],
 
           missingOperaFiles: [],
+          missingChoiceFiles: [],
         },
       };
     }
@@ -2910,6 +3208,7 @@ export class FileProcessor {
             skippedDuplicates: [],
 
             missingOperaFiles: [],
+            missingChoiceFiles: [],
           },
         };
       }
@@ -2972,6 +3271,7 @@ export class FileProcessor {
             skippedDuplicates: [],
 
             missingOperaFiles: [],
+            missingChoiceFiles: [],
           },
         };
       }
@@ -3109,6 +3409,7 @@ export class FileProcessor {
           skippedDuplicates: [],
 
           missingOperaFiles: [],
+          missingChoiceFiles: [],
         },
       };
       /* c8 ignore stop */
@@ -3131,6 +3432,7 @@ export class FileProcessor {
           skippedDuplicates: [],
 
           missingOperaFiles: [],
+          missingChoiceFiles: [],
         },
       };
     }
@@ -3263,6 +3565,7 @@ export const handler = async (
         reportsGenerated: 0,
         skippedDuplicates: [],
         missingOperaFiles: [],
+        missingChoiceFiles: [],
       },
     };
   }
@@ -3280,5 +3583,22 @@ export function getOperaFileType(
   const name = filenameOrKey.split("/").pop() ?? filenameOrKey;
   if (/^trial_balance.*\.txt$/i.test(name)) return "trial_balance";
   if (/^stat_dmy_seg.*\.txt$/i.test(name)) return "stat_dmy_seg";
+  return null;
+}
+
+/**
+ * Determine whether a filename is a Choice Hotels file and what type it is.
+ * Returns "hotel-statistics", "journal-summary", or null.
+ *
+ * Expected filenames (after ZIP extraction):
+ *   Hotel Statistics_YYYY-MM-DD.csv  → "hotel-statistics"
+ *   Hotel Journal Summary_YYYY-MM-DD.csv → "journal-summary"
+ */
+export function getChoiceFileType(
+  filenameOrKey: string,
+): "hotel-statistics" | "journal-summary" | null {
+  const name = filenameOrKey.split("/").pop() ?? filenameOrKey;
+  if (/^hotel statistics_.*\.csv$/i.test(name)) return "hotel-statistics";
+  if (/^hotel journal summary_.*\.csv$/i.test(name)) return "journal-summary";
   return null;
 }

--- a/src/lambda/file-processor.ts
+++ b/src/lambda/file-processor.ts
@@ -3594,12 +3594,18 @@ export function getOperaFileType(
  * Expected filenames (after ZIP extraction):
  *   Hotel Statistics_YYYY-MM-DD.csv  → "hotel-statistics"
  *   Hotel Journal Summary_YYYY-MM-DD.csv → "journal-summary"
+ *
+ * Note: the email-processor's sanitizeFilename() replaces spaces with
+ * underscores before storing files in S3 (e.g. "Hotel Statistics_..."
+ * becomes "Hotel_Statistics_..."), so both the space and underscore
+ * separators must be matched here.
  */
 export function getChoiceFileType(
   filenameOrKey: string,
 ): "hotel-statistics" | "journal-summary" | null {
   const name = filenameOrKey.split("/").pop() ?? filenameOrKey;
-  if (/^hotel statistics_.*\.csv$/i.test(name)) return "hotel-statistics";
-  if (/^hotel journal summary_.*\.csv$/i.test(name)) return "journal-summary";
+  if (/^hotel[ _]statistics_.*\.csv$/i.test(name)) return "hotel-statistics";
+  if (/^hotel[ _]journal[ _]summary_.*\.csv$/i.test(name))
+    return "journal-summary";
   return null;
 }


### PR DESCRIPTION
## What
Implements the full Choice Hotels inbound pipeline for 3 properties:
- Comfort Inn - Missoula (MT118)
- Comfort Inn & Suites - Ashland (OR258)
- Comfort Inn & Suites - Spokane Valley (WA244)

**New modules (`src/choice/`):**
- `choice-journal-summary-parser.ts` — parses Hotel Journal Summary CSV (handles comma/parenthesis negative numbers, ledger column sums)
- `choice-hotel-stats-parser.ts` — parses Hotel Statistics CSV (extracts business date, handles dynamic RevPAR column header)
- `choice-mapping-loader.ts` — loads Choice mapping XLSX from `choice/` S3 prefix (7-column `Choice` sheet, property-specific overrides)
- `choice-transformation.ts` — transforms parsed data into JE and StatJE records (always appends 3 trailing zero rows for Occy/ADR/RevPAR)

**`email-processor` changes:**
- Accepts `.zip` attachments as valid
- Extracts CSVs from ZIP via `adm-zip`
- Routes the shared sender (`AUTO_MAIL_DELIVERY_SYSTEM@choicehotels.com`) using a `__choice__` SSM sentinel; resolves property slug via a second `choice:{code}` SSM lookup

**`file-processor` changes:**
- Detects Choice files by filename pattern (`Hotel Statistics_*.csv`, `Hotel Journal Summary_*.csv`)
- Bypasses standard CSV parser and feeds raw content directly to Choice parsers
- Pairs hotel-statistics + journal-summary files per property+date
- Reports missing files in the summary email (`missingChoiceFiles`)

**Config / property changes:**
- 3 new Choice properties in `property-config.ts` with `choiceMappingName` field
- `report-email-sender` renders a new Missing Choice Hotels Files warning section

**Docs:**
- `docs/choice-hotels-pipeline.md` — full technical reference
- `AGENTS.md`, `PROJECT_PLAN.md`, `docs/architecture.json` updated

## Why
Phase 14 of the project roadmap. Choice Hotels properties send Night Audit reports daily as ZIP attachments from a shared sender address. The existing VM and Opera pipelines could not handle ZIP extraction or shared-sender routing, requiring a dedicated pipeline.

## Testing
- 673 tests passing (up from 659 pre-implementation)
- All coverage thresholds maintained: 86.21% statements, 75.19% branches, 88.8% functions, 86.88% lines
- New test files: parsers, mapping loader, transformation, email-processor ZIP handling, file-processor file-type detection
- Build, lint, format, and security audit all pass

**Note:** SSM entries and Choice mapping XLSX upload are not part of this PR — those are deployment steps to be done manually before enabling the pipeline in dev/prod. The code is inert until those SSM keys exist.

Made with [Cursor](https://cursor.com)